### PR TITLE
おすすめの拡張機能を表示するよう変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ pnpm-debug.log*
 
 # Editor directories and files
 .idea
-.vscode
 *.suo
 *.ntvs*
 *.njsproj
@@ -38,3 +37,10 @@ data/
 
 # release
 electron-builder.yml
+
+# vscode
+.vscode/*
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/launch.json
+!.vscode/extensions.json

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "octref.vetur",
+    "dbaeumer.vscode-eslint"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "octref.vetur",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode"
   ]
 }


### PR DESCRIPTION
おすすめ拡張機能として[Vetur][]、[ESLint][]、[Prettier - Code formatter][]が表示されるようにしました

vscodeに上記の拡張機能が入っていない状態でプロジェクトを開くと、インストールするよう促してくれるようになります

![image](https://user-images.githubusercontent.com/25514849/127795533-69b2446b-32ec-487d-bb66-1cf6486d7a23.png)

[Vetur]: https://marketplace.visualstudio.com/items?itemName=octref.vetur
[ESLint]: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
[Prettier - Code formatter]: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode