### PR TITLE
保存するファイル名を `001_四国めたん_こんにちは.wav` のようなものに変更する

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -182,9 +182,10 @@ ipcMain.handle(GET_OSS_LICENSES, (event) => {
   return ossLicenses;
 });
 
-ipcMain.handle(SHOW_SAVE_DIALOG, (event, { title }: { title: string }) => {
+ipcMain.handle(SHOW_SAVE_DIALOG, (event, { title, defaultPath }: { title: string, defaultPath?: string }) => {
   return dialog.showSaveDialogSync(win, {
     title,
+    defaultPath,
     filters: [{ name: "Wave File", extensions: ["wav"] }],
     properties: ["createDirectory"],
   });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -38,8 +38,8 @@ const api: Sandbox = {
     return new TextDecoder().decode(buf);
   },
 
-  showSaveDialog: ({ title }) => {
-    return ipcRenderer.invoke(SHOW_SAVE_DIALOG, { title });
+  showSaveDialog: ({ title, defaultPath }) => {
+    return ipcRenderer.invoke(SHOW_SAVE_DIALOG, { title, defaultPath });
   },
 
   showOpenDirectoryDialog: ({ title }) => {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -21,6 +21,17 @@ async function generateUniqueId(audioItem: AudioItem) {
     .join("");
 }
 
+function buildFileName(character: CharactorInfo, text: string) {
+  // eslint-disable-next-line no-control-regex
+  const sanitizer = /[\x00-\x1f\x22\x2a\x2f\x3a\x3c\x3e\x3f\x7c\x7f]/g;
+  const characterName = character.metas.name.replace(sanitizer, '');
+  text = text.replace(sanitizer, '');
+  if (text.length > 10) {
+    text = text.substring(0, 9) + "…";
+  }
+  return characterName + "_" + text + ".wav";
+}
+
 export const SET_ENGINE_READY = "SET_ENGINE_READY";
 export const START_WAITING_ENGINE = "START_WAITING_ENGINE";
 export const ACTIVE_AUDIO_KEY = "ACTIVE_AUDIO_KEY";
@@ -459,7 +470,9 @@ export const audioStore = {
         });
         if (dirPath) {
           const promises = state.audioKeys.map((audioKey, index) => {
-            const name = (index + 1).toString().padStart(3, "0") + ".wav";
+            const audioItem = state.audioItems[audioKey];
+            const character = state.charactorInfos![audioItem.charactorIndex!];
+            const name = (index + 1).toString().padStart(3, "0") + "_" + buildFileName(character, audioItem.text);
             return dispatch(GENERATE_AND_SAVE_AUDIO, {
               audioKey,
               filePath: path.join(dirPath!, name),

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -23,7 +23,7 @@ async function generateUniqueId(audioItem: AudioItem) {
 
 function buildFileName(state: State, audioKey: string) {
   // eslint-disable-next-line no-control-regex
-  const sanitizer = /[\x00-\x1f\x22\x2a\x2f\x3a\x3c\x3e\x3f\x7c\x7f]/g;
+  const sanitizer = /[\x00-\x1f\x22\x2a\x2f\x3a\x3c\x3e\x3f\x5c\x7c\x7f]/g;
   const index = state.audioKeys.indexOf(audioKey);
   const audioItem = state.audioItems[audioKey];
   const character = state.charactorInfos![audioItem.charactorIndex!];

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -3,7 +3,7 @@ export interface Sandbox {
   getOssLicenses(): Promise<Record<string, string>[]>;
   saveTempAudioFile(obj: { relativePath: string; buffer: ArrayBuffer }): void;
   loadTempFile(): Promise<string>;
-  showSaveDialog(obj: { title: string }): Promise<string | undefined>;
+  showSaveDialog(obj: { title: string, defaultPath?: string }): Promise<string | undefined>;
   showOpenDirectoryDialog(obj: { title: string }): Promise<string | undefined>;
   writeFile(obj: { filePath: string; buffer: ArrayBuffer });
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;


### PR DESCRIPTION
ファイル名が `001.wav` だと後でファイルの内容がわかりづらくなってしまうので、
`001_四国めたん_こんにちは.wav` のような `通し番号_キャラ名_セリフ.wav` の形式になるように変更しました。
セリフが長い場合は `001_四国めたん_長いセリフを喋って….wav` のように9文字＋ "…" の形式になります。

また、`GENERATE_AND_SAVE_AUDIO` で `filePath` を省略したときに表示される「名前を付けて保存」のダイアログでも、
同じ形式のファイル名が予め入力されている状態になるよう変更しました。