### PR TITLE
音声ファイルと同じ名前でテキストファイルを保存する

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -439,7 +439,7 @@ export const audioStore = {
     ),
     [GENERATE_AND_SAVE_AUDIO]: createUILockAction(
       async (
-        { dispatch },
+        { state, dispatch },
         { audioKey, filePath }: { audioKey: string; filePath?: string }
       ) => {
         const blob: Blob = await dispatch(GENERATE_AUDIO, { audioKey });
@@ -448,6 +448,12 @@ export const audioStore = {
           window.electron.writeFile({
             filePath,
             buffer: await blob.arrayBuffer(),
+          });
+          const bom = new Uint8Array([0xef, 0xbb, 0xbf]);
+          const textBlob = new Blob([bom, state.audioItems[audioKey].text], {type: 'text/plain'});
+          window.electron.writeFile({
+            filePath: filePath.replace(/\.wav$/, ".txt"),
+            buffer: await textBlob.arrayBuffer(),
           });
         }
       }


### PR DESCRIPTION
市販の音声合成ソフトでは、音声ファイルと同じ名前でセリフ本文をテキストファイルに保存する機能があることが多いです。
その動作に倣い、BOM 付き UTF-8 でテキストファイルを作成する機能を追加します。

この機能があると、動画編集ソフトで字幕として取り込めるようになることがあります。
（例: [YMM4](https://manjubox.net/ymm4/faq/%E3%82%86%E3%81%A3%E3%81%8F%E3%82%8A%E3%83%9C%E3%82%A4%E3%82%B9/%E5%A4%96%E9%83%A8%E3%81%AE%E9%9F%B3%E5%A3%B0%E5%90%88%E6%88%90%E3%82%A8%E3%83%B3%E3%82%B8%E3%83%B3%E3%81%A7%E4%BD%9C%E6%88%90%E3%81%97%E3%81%9F%E9%9F%B3%E5%A3%B0%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%97%E3%81%9F%E3%81%84/)）