### PR TITLE
セルを右クリックしてアイテムを削除できるように

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -178,13 +178,19 @@ export const audioStore = {
         };
       }
     ),
-    [REMOVE_AUDIO_ITEM]: createCommandAction(
-      (draft, { audioKey }: { audioKey: string }) => {
-        draft.audioKeys.splice(draft.audioKeys.indexOf(audioKey), 1);
-        delete draft.audioItems[audioKey];
-        delete draft.audioStates[audioKey];
-      }
-    ),
+    [REMOVE_AUDIO_ITEM](
+      { state, dispatch },
+      { audioKey }: { audioKey: string | undefined }
+    ) {
+      const index =
+        audioKey !== undefined
+          ? state.audioKeys.indexOf(audioKey)
+          : state.audioKeys.length;
+      state.audioKeys.splice(index, 1);
+      delete state.audioItems[index];
+      delete state.audioStates[index];
+      return state.audioKeys[index];
+    },
     [REGISTER_AUDIO_ITEM](
       { state, dispatch },
       {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -53,6 +53,7 @@
               :key="audioKey"
               :audioKey="audioKey"
               @focusCell="focusCell"
+              @click.right="removeAudioItem"
               :ref="addAudioCellRef"
             />
           </div>
@@ -105,6 +106,7 @@ import {
   LOAD_CHARACTOR,
   PLAY_CONTINUOUSLY_AUDIO,
   REGISTER_AUDIO_ITEM,
+  REMOVE_AUDIO_ITEM,
   START_WAITING_ENGINE,
   STOP_CONTINUOUSLY_AUDIO,
 } from "@/store/audio";
@@ -203,6 +205,18 @@ export default defineComponent({
       audioCellRefs[newAudioKey].focusTextField();
     };
 
+    // セルを削除して移動
+    const removeAudioItem = async ({
+      audioKey,
+    }: {
+      audioKey: string;
+    }) => {
+      const index = await store.dispatch(REMOVE_AUDIO_ITEM, {
+        audioKey: activeAudioKey.value,
+      });
+      audioCellRefs[index].focusTextField();
+    };
+
     // セルをフォーカス
     const focusCell = ({ audioKey }: { audioKey: string }) => {
       audioCellRefs[audioKey].focusTextField();
@@ -235,6 +249,7 @@ export default defineComponent({
       addAudioCellRef,
       addAudioItem,
       addAndMoveCell,
+      removeAudioItem,
       focusCell,
       playContinuously,
       stopContinuously,
@@ -335,6 +350,7 @@ body {
     overflow-x: hidden;
     overflow-y: scroll;
 
+    user-select: none;
     position: absolute;
     top: 0;
     bottom: 0;


### PR DESCRIPTION
テキストボックスを空にしてから、もう一度 Backspace を押すと、削除できますが、
UI として伝わりにくいと思ったため、右クリックしたら削除できるようにしました。
本来メニューを出してあげるべきかと思いますが、一旦この形にしました。

https://user-images.githubusercontent.com/237271/127897822-1f346821-a1c6-4757-bd73-1b22a9b7d7b2.mp4

