### PR TITLE
Menuから音声合成エンジンの起動モードを変更出来るようにする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -128,7 +128,7 @@ const menu = MenuBuilder()
 
     dialog.showMessageBoxSync(win, {
       message: "エンジンの起動モードを変更しました",
-      detail: "起動モード変更の反映は次回のソフトウェア起動時に行われます。",
+      detail: "変更を適用するためにVOICEVOXを再起動してください。",
     });
 
     menu.setActiveLaunchMode(store.get("useGpu", false) as boolean);

--- a/src/background.ts
+++ b/src/background.ts
@@ -28,6 +28,7 @@ import {
   SHOW_IMPORT_FILE_DIALOG,
   SHOW_SAVE_DIALOG,
 } from "./electron/ipc";
+import { MenuBuilder } from "./electron/menu";
 
 import fs from "fs";
 import { CharactorInfo } from "./type/preload";
@@ -120,10 +121,24 @@ const updateInfos = JSON.parse(
   })
 );
 
+// initialize menu
+const menu = MenuBuilder()
+  .setOnLaunchModeItemClicked((useGpu) => {
+    store.set("useGpu", useGpu);
+
+    dialog.showMessageBoxSync(win, {
+      message: "音声合成エンジン起動モードの変更が完了しました",
+      detail: "起動モード変更の反映は次回のソフトウェア起動時に行われます。",
+    });
+
+    menu.setActiveLaunchMode(store.get("useGpu", false) as boolean);
+  })
+  .build();
+Menu.setApplicationMenu(menu.instance);
+
+menu.setActiveLaunchMode(store.get("useGpu", false) as boolean);
+
 // create window
-if (!isDevelopment) {
-  Menu.setApplicationMenu(null);
-}
 async function createWindow() {
   win = new BrowserWindow({
     width: 800,

--- a/src/background.ts
+++ b/src/background.ts
@@ -127,7 +127,7 @@ const menu = MenuBuilder()
     store.set("useGpu", useGpu);
 
     dialog.showMessageBoxSync(win, {
-      message: "音声合成エンジン起動モードの変更が完了しました",
+      message: "エンジンの起動モードを変更しました",
       detail: "起動モード変更の反映は次回のソフトウェア起動時に行われます。",
     });
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -182,6 +182,7 @@ async function createHelpWindow() {
     },
     icon: path.join(__static, "icon.png"),
   });
+  child.removeMenu();
 
   if (process.env.WEBPACK_DEV_SERVER_URL) {
     await child.loadURL(

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -1,0 +1,104 @@
+import { Menu, MenuItem } from "electron";
+
+const MENU_ROOT_ITEM_ENGINE_ID = "engine";
+const MENU_SUBMENU_ITEM_LAUNCHMODE_ID = "launchMode";
+const MENU_SUBMENU_CHILD_CPU_ID = "cpu";
+const MENU_SUBMENU_CHILD_GPU_ID = "gpu";
+
+type BuiltMenu = {
+  instance: Menu;
+  setActiveLaunchMode: (useGpu: boolean) => void;
+};
+
+const setActiveLaunchMode = (useGpu: boolean) => {
+  const applicationMenu = Menu.getApplicationMenu();
+  if (applicationMenu === null) {
+    return;
+  }
+  applicationMenu.items.forEach((rootMenu) => {
+    if (rootMenu.id !== MENU_ROOT_ITEM_ENGINE_ID) {
+      return;
+    }
+    rootMenu.submenu?.items.forEach((subMenu) => {
+      if (subMenu.id !== MENU_SUBMENU_ITEM_LAUNCHMODE_ID) {
+        return;
+      }
+      subMenu.submenu?.items.forEach((launchModeItem) => {
+        launchModeItem.checked =
+          launchModeItem.id === MENU_SUBMENU_CHILD_GPU_ID ? useGpu : !useGpu;
+      });
+    });
+  });
+};
+
+const createMenu = () => {
+  // 外部から設定するCallback
+  let onLaunchModeItemClickedImpl: (useGpu: boolean) => void;
+
+  // Callback Wrapper
+  const onLaunchModeItemClicked = (item: MenuItem) => {
+    const useGpu = item.id === MENU_SUBMENU_CHILD_GPU_ID;
+    onLaunchModeItemClickedImpl?.(useGpu);
+  };
+
+  type ElectronMenuTemplate = Parameters<typeof Menu.buildFromTemplate>[0];
+
+  const menuTemplate: ElectronMenuTemplate = [
+    {
+      id: MENU_ROOT_ITEM_ENGINE_ID,
+      label: "エンジン",
+      submenu: [
+        {
+          id: MENU_SUBMENU_ITEM_LAUNCHMODE_ID,
+          label: "起動モード",
+          submenu: [
+            {
+              id: MENU_SUBMENU_CHILD_CPU_ID,
+              label: "CPU",
+              type: "checkbox",
+              click: onLaunchModeItemClicked,
+            },
+            {
+              id: MENU_SUBMENU_CHILD_GPU_ID,
+              label: "GPU",
+              type: "checkbox",
+              click: onLaunchModeItemClicked,
+            },
+          ],
+        },
+      ],
+    },
+  ];
+
+  const menu = Menu.buildFromTemplate(menuTemplate);
+
+  return {
+    menuInstance: menu,
+    setOnLaunchModeItemClicked: (cb: (useGpu: boolean) => void) =>
+      (onLaunchModeItemClickedImpl = cb),
+    setActiveLaunchMode,
+  };
+};
+
+class MenuBuilderImpl {
+  private readonly _menu: ReturnType<typeof createMenu>;
+
+  constructor() {
+    this._menu = createMenu();
+  }
+
+  setOnLaunchModeItemClicked(cb: (useGpu: boolean) => void): MenuBuilderImpl {
+    this._menu.setOnLaunchModeItemClicked(cb);
+    return this;
+  }
+
+  build(): BuiltMenu {
+    return {
+      instance: this._menu.menuInstance,
+      setActiveLaunchMode: this._menu.setActiveLaunchMode,
+    };
+  }
+}
+
+const _menuBuilder = new MenuBuilderImpl();
+export const MenuBuilder = (): MenuBuilderImpl => _menuBuilder;


### PR DESCRIPTION
close: https://github.com/Hiroshiba/voicevox/issues/23

機能の充実に連れて、UIの上段のバーにボタンが増えていくことが予想される。

そのため、使われる頻度の低い機能の実装箇所であったり、ショートカットキーでの操作などが実装しやすいMenuを提供し、そこに機能を追加していくことはUIやUXの観点で良いだろうと判断した。

今回そのMenuに、使われる頻度は非常に低い機能であると考えられる音声合成エンジンの起動モードの変更機能を実装した。

<img src="https://user-images.githubusercontent.com/1955233/128351809-7c1689af-baac-498e-8330-dad162c73c8c.png" width="600" />

## 大きな変更点

### Menuを使うようにしたため、Window上部のすっきりさが失われた

今回は使われる頻度が低い機能と判断しMenuに実装したが、一つしかMenuItemがなく逆に目立ってしまっている
これがアプリケーションの表示的なデザインとして妥当であるかレビューをお願いしたいです

今回エンジンというMenuLabelにした理由としては
https://github.com/Hiroshiba/voicevox/issues/16
MenuにEngineの状態に応じてEngineをリスタートする機能なども追加できるのではと考えたり、
またEngineの待ち受けのURL（外部GPUマシンなど）の変更の機能（あったらいいなと思っているのですが）がそのItemにまとめられるのではと考えたためです
 
