### PR TITLE
セリフ読み込み時のバグを修正

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -31,7 +31,7 @@ function parseTextFile(
   if (!charactors.size) return [];
 
   const audioItems: AudioItem[] = [];
-  const seps = [",", "\n"];
+  const seps = [",", "\r\n", "\n"];
   let lastCharactorIndex = 0;
   for (const splittedText of body.split(new RegExp(`${seps.join("|")}`, "g"))) {
     const charactorIndex = charactors.get(splittedText);


### PR DESCRIPTION
テキストファイルからセリフを読み込む機能において、改行で区切るとキャラクター名が正しく設定されないことに気づきました。

改行コードがCRLFである場合を見落としていたことが原因だったので、区切り文字に"\r\n"を追加しました。