### PR TITLE
型定義の誤りを直す

### DIFF
--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -12,9 +12,9 @@ export interface Sandbox {
   showOpenDirectoryDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectSaveDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
-  showConfirmDialog(obj: { title: string; message: string }): Primise<boolean>;
+  showConfirmDialog(obj: { title: string; message: string }): Promise<boolean>;
   showImportFileDialog(obj: { title: string }): Promise<string | undefined>;
-  writeFile(obj: { filePath: string; buffer: ArrayBuffer });
+  writeFile(obj: { filePath: string; buffer: ArrayBuffer }): void;
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;
   createHelpWindow(): void;
 }

--- a/src/type/shims-vue.d.ts
+++ b/src/type/shims-vue.d.ts
@@ -1,6 +1,5 @@
 /* eslint-disable */
 declare module "*.vue" {
-  // @ts-ignore
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;
 

--- a/src/type/shims-vue.d.ts
+++ b/src/type/shims-vue.d.ts
@@ -1,18 +1,12 @@
 /* eslint-disable */
 declare module "*.vue" {
+  // @ts-ignore
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;
-  export default component;
 
-  declare global {
-    interface Window {
-      readonly electron: import("./preload").Sandbox;
-    }
-  }
+  export default component;
 }
 
-declare global {
-  interface Window {
-    readonly electron: import("./preload").Sandbox;
-  }
+interface Window {
+  readonly electron: import("./preload").Sandbox;
 }


### PR DESCRIPTION
tsconfig.jsonの `skipLibCheck`を`false`にした際いくつか型の誤りを検出できたのでそれを修正する。

厳密に行いたい場合は`false`にする方が良いが、npmがv6系とv7系で分かれていて、lockが何度も書き換わり意味をなしていない状態で `false` にすると `@types` 系のバージョンの差異などでビルドが通らないなどの不都合が出るだろう。

ということで、本PRではその変更を行わずに、型の誤りのみを修正した。