### PR TITLE
開発時にelectronのデフォルトメニューを表示する

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -127,6 +127,7 @@ const updateInfos = JSON.parse(
 
 // initialize menu
 const menu = MenuBuilder()
+  .configure(isDevelopment)
   .setOnLaunchModeItemClicked((useGpu) => {
     store.set("useGpu", useGpu);
 

--- a/src/electron/menu.ts
+++ b/src/electron/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, MenuItem } from "electron";
+import { Menu, MenuItem, MenuItemConstructorOptions } from "electron";
 
 const MENU_ROOT_ITEM_ENGINE_ID = "engine";
 const MENU_SUBMENU_ITEM_LAUNCHMODE_ID = "launchMode";
@@ -85,6 +85,21 @@ class MenuBuilderImpl {
 
   constructor() {
     this._menu = createMenu();
+  }
+
+  configure(isDevelopment: boolean): MenuBuilderImpl {
+    if (isDevelopment) {
+      const defaultMenuItemOptions: MenuItemConstructorOptions[] = [
+        { role: "fileMenu" },
+        { role: "editMenu" },
+        { role: "viewMenu" },
+        { role: "windowMenu" },
+      ];
+      defaultMenuItemOptions.forEach((option) =>
+        this._menu.menuInstance.append(new MenuItem(option))
+      );
+    }
+    return this;
   }
 
   setOnLaunchModeItemClicked(cb: (useGpu: boolean) => void): MenuBuilderImpl {


### PR DESCRIPTION
#29 でカスタムメニューが追加されたため、開発時にリロードなどの機能が使えなくなっていました。
よって、開発時にはelectronのデフォルトメニューがカスタムメニューと一緒に表示されるようにしました。