### PR TITLE
音声を一つだけ保存する時の GUI レスポンスを改善

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -492,11 +492,14 @@ export const audioStore = {
         { state, dispatch },
         { audioKey, filePath }: { audioKey: string; filePath?: string }
       ) => {
-        const blob: Blob = await dispatch(GENERATE_AUDIO, { audioKey });
+        const blobPromise: Promise<Blob> = dispatch(GENERATE_AUDIO, {
+          audioKey,
+        });
         filePath ??= await window.electron.showAudioSaveDialog({
           title: "Save",
           defaultPath: buildFileName(state, audioKey),
         });
+        const blob = await blobPromise;
         if (filePath) {
           window.electron.writeFile({
             filePath,


### PR DESCRIPTION
音声を一つだけ保存するボタンを押した際、元々のコードでは

1. `GENERATE_AUDIO` が終わるまで待機
2. 「名前を付けて保存」のダイアログを表示する

という処理の流れになっています。

これだとボタン押してもすぐにダイアログが出ないのでレスポンスが悪く感じますし、
人間がダイアログで必要な操作を終えるには速くても数秒程度かかるはずなので、
この時間を利用して裏で `GENERATE_AUDIO` を進めておいたほうが、待ち時間を減らせます。

そこで `GENERATE_AUDIO` をすぐに `await` せずに一旦 `Promise` で受け取り、あとで `await` するように変更しました。
ここは `Promise.all` が使えそうなシーンですが、`??=` 演算子のエレガントな処理に悩んだので単純な方法にしました。