### PR TITLE
システム設定に関わらずライトテーマを適用する

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -13,6 +13,7 @@ import {
   dialog,
   Menu,
   shell,
+  nativeTheme,
 } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import installExtension, { VUEJS_DEVTOOLS } from "electron-devtools-installer";
@@ -132,6 +133,7 @@ menu.setActiveLaunchMode(store.get("useGpu", false) as boolean);
 
 // create window
 async function createWindow() {
+  nativeTheme.themeSource = "light";
   win = new BrowserWindow({
     width: 800,
     height: 600,


### PR DESCRIPTION
デフォルトだとシステム側の設定によってメニューバーの色が変わってしまうようなので、常にライトテーマを使用するようにしました

![image](https://user-images.githubusercontent.com/25514849/128989059-b7054c09-79e0-48b7-bb8b-21e9a9746d6b.png)

UI全体をダークテーマに対応させようかとも考えましたが、タイトルバーはどうあがいても色を変えられないようです electron/electron#27100
フレームレスウィンドウにしてタイトルバーを自作するという手もありますが、そうすると今度はメニューバーも自作することになってしまうのでかなり大きな変更になってしまいます