### PR TITLE
#89 バグ修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -22,15 +22,13 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const uiLocked = computed(() => store.getters[UI_LOCKED]);
-    const isEngineReady = computed(() => store.state.isEngineReady);
 
     const updateMenu = () => {
       store.dispatch(UPDATE_MENU, {
-        uiLocked: uiLocked.value || !isEngineReady.value,
+        uiLocked: uiLocked.value,
       });
     };
     watch(uiLocked, updateMenu);
-    watch(isEngineReady, updateMenu);
     updateMenu();
 
     window.electron.onReceivedIPCMsg(IPC_GENERATE_AND_SAVE_ALL_AUDIO, () => store.dispatch(GENERATE_AND_SAVE_ALL_AUDIO, {}));


### PR DESCRIPTION
#89

メニューの無効化処理を`App.vue`に書いたため、ヘルプウインドウでも`isEngineReady`をチェックしており、正常に判定できていませんでした。(ヘルプウインドウでは常に`false`になる)
`isEngineReady`を使わなくとも無効化判定ができたので、削除しました。

本質的には、メインウインドウのメニュー処理を`App.vue`から切り離すべきですが、メニューをVueで実装するプルリクがあるので、上記の修正にとどめました。