### PR TITLE
GitHub Actionsにタイポ検知を追加

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,19 @@
+---
+# yamllint disable rule:line-length
+name: check_typos
+
+on:  # yamllint disable-line rule:truthy
+  push:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: typos-action
+        uses: crate-ci/typos@v1.0.4

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ npm run electron:build
 npm run fmt
 ```
 
+## タイポチェック
+
+[typos](https://github.com/crate-ci/typos)を使ってタイポのチェックを行っています。
+[typosをインストール](https://github.com/crate-ci/typos#install)した後
+
+```bash
+typos
+```
+
+でタイポチェックを行えます。
+もし誤判定やチェックから除外すべきファイルがあれば
+[設定ファイルの説明](https://github.com/crate-ci/typos#false-positives)に従って``_typos.toml``を編集してください．
+
+
 ## OpenAPI generator
 
 音声合成エンジンが起動している状態で以下のコマンドを実行してください。

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,9 @@
+# Files for typos
+# Instruction:  https://github.com/marketplace/actions/typos-action#getting-started
+
+[default.extend-identifiers]
+
+[default.extend-words]
+
+[files]
+extend-exclude = ["package-lock.json"]


### PR DESCRIPTION
https://github.com/Hiroshiba/voicevox/pull/65#issuecomment-898911701 の実装です．
誤判定の回避は https://github.com/crate-ci/typos#false-positives のように ``_typos.toml``を編集します