### PR TITLE
音高の値をSliderの上に表示する

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -498,6 +498,7 @@ $pitch-label-height: 24px;
     margin-left: 5px;
     margin-right: 5px;
     margin-bottom: 5px;
+    padding-left: 5px;
 
     display: flex;
     overflow-x: scroll;

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -143,6 +143,7 @@
               >
                 <q-badge
                   class="pitch-label"
+                  text-color="secondary"
                   v-if="
                     (pitchLabel.visible || pitchLabel.panning) &&
                     pitchLabel.accentPhraseIndex == accentPhraseIndex &&

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -235,7 +235,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from "vue";
+import { computed, defineComponent, reactive, ref } from "vue";
 import { useStore } from "@/store";
 import {
   ACTIVE_AUDIO_KEY,
@@ -251,19 +251,6 @@ import Mousetrap from "mousetrap";
 
 export default defineComponent({
   name: "AudioDetail",
-
-  data() {
-    return {
-      pitchLabel: {
-        visible: false,
-        // NOTE: q-slider操作中の表示のON/OFFは@panに渡ってくるphaseで判定する
-        // SEE: https://github.com/quasarframework/quasar/issues/7739#issuecomment-689664504
-        panning: false,
-        accentPhraseIndex: -1,
-        moraIndex: -1,
-      },
-    };
-  },
 
   setup() {
     const store = useStore();
@@ -417,6 +404,30 @@ export default defineComponent({
       () => store.state.nowPlayingContinuously
     );
 
+    const pitchLabel = reactive({
+      visible: false,
+      // NOTE: q-slider操作中の表示のON/OFFは@panに渡ってくるphaseで判定する
+      // SEE: https://github.com/quasarframework/quasar/issues/7739#issuecomment-689664504
+      panning: false,
+      accentPhraseIndex: -1,
+      moraIndex: -1,
+    });
+
+    const setPitchLabel = (
+      visible: boolean,
+      accentPhraseIndex: number | undefined,
+      moraIndex: number | undefined
+    ) => {
+      pitchLabel.visible = visible;
+      pitchLabel.accentPhraseIndex =
+        accentPhraseIndex ?? pitchLabel.accentPhraseIndex;
+      pitchLabel.moraIndex = moraIndex ?? pitchLabel.moraIndex;
+    };
+
+    const setPitchPanning = (panningPhase: string) => {
+      pitchLabel.panning = panningPhase === "start";
+    };
+
     return {
       selectDetail,
       selectedDetail,
@@ -439,24 +450,10 @@ export default defineComponent({
       nowPlaying,
       nowGenerating,
       nowPlayingContinuously,
+      pitchLabel,
+      setPitchLabel,
+      setPitchPanning,
     };
-  },
-
-  methods: {
-    setPitchLabel(
-      visible: boolean,
-      accentPhraseIndex: number | undefined,
-      moraIndex: number | undefined
-    ) {
-      this.pitchLabel.visible = visible;
-      this.pitchLabel.accentPhraseIndex =
-        accentPhraseIndex ?? this.pitchLabel.accentPhraseIndex;
-      this.pitchLabel.moraIndex = moraIndex ?? this.pitchLabel.moraIndex;
-    },
-
-    setPitchPanning(panningPhase: string) {
-      this.pitchLabel.panning = panningPhase === "start";
-    },
   },
 });
 </script>


### PR DESCRIPTION
close #79 

マウスカーソルがSliderの上にいるときに音高の値を表示するようにしました。
該当IssueではQSliderのlabelをCSSで変更して利用してはどうか、という事でしたが、値の桁数が多くなると隣のSliderに被ってしまうため、Slider上部に表示するようにしてみました。

## Screenshot

![image](https://user-images.githubusercontent.com/936617/129469240-bbcdf327-d321-4234-afd8-750ef72d680b.png)

## その他

音高の表示に関しては完全にViewの見た目のみの状態のためdata/methodsを使っていますが、Storeに追加してsetupを使うべき、等があれば指摘いただけると助かります