### PR TITLE
プロジェクト読み込み時の問題を修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -317,6 +317,14 @@ ipcMain.handle("SHOW_CONFIRM_DIALOG", (event, { title, message }) => {
     });
 });
 
+ipcMain.handle("SHOW_ERROR_DIALOG", (event, { title, message }) => {
+  return dialog.showMessageBox(win, {
+    type: "error",
+    title: title,
+    message: message,
+  });
+});
+
 ipcMain.handle("SHOW_IMPORT_FILE_DIALOG", (event, { title }) => {
   return dialog.showOpenDialogSync(win, {
     title,

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -58,6 +58,10 @@ const api: Sandbox = {
     return ipcRenderer.invoke("SHOW_CONFIRM_DIALOG", { title, message });
   },
 
+  showErrorDialog: ({ title, message }) => {
+    return ipcRenderer.invoke("SHOW_ERROR_DIALOG", { title, message });
+  },
+
   showImportFileDialog: ({ title }) => {
     return ipcRenderer.invoke("SHOW_IMPORT_FILE_DIALOG", { title });
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -73,6 +73,10 @@ export const store = createStore<State>({
           const text = new TextDecoder("utf-8").decode(buf).trim();
           const obj = JSON.parse(text);
           if (!(await projectValidationCheck(obj, true))) {
+            window.electron.showErrorDialog({
+              title: "エラー",
+              message: "ファイルフォーマットが正しくありません。",
+            });
             return;
           }
           const projectData = obj as ProjectData;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -214,7 +214,7 @@ const projectSchema = {
         characterIndex: { type: "number" },
         query: { $ref: "#/$defs/AudioQuery" },
       },
-      required: ["text"],
+      required: ["text", "characterIndex"],
     },
   },
 };

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -59,6 +59,11 @@ type IpcData = {
     return: boolean;
   };
 
+  SHOW_ERROR_DIALOG: {
+    args: [obj: { title: string; message: string }];
+    return: void;
+  };
+
   OPEN_TEXT_EDIT_CONTEXT_MENU: {
     args: [];
     return: void;

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -16,6 +16,7 @@ export interface Sandbox {
   showProjectSaveDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
   showConfirmDialog(obj: { title: string; message: string }): Promise<boolean>;
+  showErrorDialog(obj: { title: string; message: string }): Promise<void>;
   showImportFileDialog(obj: { title: string }): Promise<string | undefined>;
   writeFile(obj: { filePath: string; buffer: ArrayBuffer }): void;
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;


### PR DESCRIPTION
現在、以下の様なプロジェクトを読み込むと、バリデーションは通りますが、`Unhandled Error`が出ます。([error.log](https://github.com/Hiroshiba/voicevox/files/6988194/error.log))

`audioItems`に`characterIndex`が存在しないプロジェクト
```json
{
   "appVersion": "0.3.1",
   "audioKeys": [
      "0f2f6793-27a7-4379-bc99-3be76a189196"
   ],
   "audioItems": {
      "0f2f6793-27a7-4379-bc99-3be76a189196": {
         "text": "プロジェクト",
      }
   }
}
```

view側の複数のコードが`characterIndex`が`undefined`でないことを前提に書かれていることが原因だと思います。
通常なら問題ありませんが、#65 でプロジェクトファイルのキー`charactorIndex`が`characterIndex`に修正されたので、バージョンを上げるとユーザーが遭遇する可能性があります。

よって、プロジェクト読み込み時、`characterIndex`を必須パラメータとし、バリデーションでエラーを出す + エラーをダイアログで通知するように変更しました。