### PR TITLE
mount前にelectronへの依存を一箇所に詰め込む

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,9 +3,9 @@
 </template>
 
 <script type="ts">
-import { defineComponent } from "vue";
-import { useStore, LOAD_PROJECT_FILE } from "@/store";
+import { useStore } from "@/store";
 import { GET_USE_GPU } from "@/store/ui";
+import { defineComponent } from "vue";
 
 export default defineComponent({
   name: "App",
@@ -14,9 +14,6 @@ export default defineComponent({
     const store = useStore();
 
     store.dispatch(GET_USE_GPU);
-
-    window.electron.onReceivedIPCMsg("LOAD_PROJECT_FILE",
-      (_, { filePath, confirm } = {}) => store.dispatch(LOAD_PROJECT_FILE, { filePath, confirm }));
   }
 });
 </script>

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import router from "./router";
 import { store, storeKey } from "./store";
+import { ipcMessageReceiver } from "./plugins/ipcMessageReceiverPlugin";
 
 import { Quasar, Dialog, Loading } from "quasar";
 import iconSet from "quasar/icon-set/material-icons";
@@ -24,4 +25,5 @@ createApp(App)
       Loading,
     },
   })
+  .use(ipcMessageReceiver, { store: store })
   .mount("#app");

--- a/src/plugins/ipcMessageReceiverPlugin.ts
+++ b/src/plugins/ipcMessageReceiverPlugin.ts
@@ -1,0 +1,13 @@
+import { LOAD_PROJECT_FILE } from "@/store";
+import { App } from "vue";
+import { Store } from "vuex";
+
+export const ipcMessageReceiver = {
+  install: (_: App, options: { store: Store<unknown> }): void => {
+    window.electron.onReceivedIPCMsg(
+      "LOAD_PROJECT_FILE",
+      (_, { filePath, confirm } = {}) =>
+        options.store.dispatch(LOAD_PROJECT_FILE, { filePath, confirm })
+    );
+  },
+};

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -119,7 +119,7 @@ declare namespace Electron {
       channel: T,
       listener: (
         event: import("electron").IpcRendererEvent,
-        ...args: IpcSOData[T]
+        ...args: IpcSOData[T]["args"]
       ) => void
     ): this;
   }

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -26,7 +26,7 @@ export interface Sandbox {
   isAvailableGPUMode(): Promise<boolean>;
   onReceivedIPCMsg: <T extends keyof IpcSOData>(
     channel: T,
-    listener: (event: IpcRendererEvent, ...args: IpcSOData[T]) => void
+    listener: (event: IpcRendererEvent, ...args: IpcSOData[T]["args"]) => void
   ) => IpcRenderer;
 }
 


### PR DESCRIPTION
現時点Windowにelectronが見えるので、.vue内で呼びたくなってしまうけれども、View内に置いてしまうと将来的にテストが困難になる恐れがあるため.vueファイルから排除しておきたい。
pluginという形で依存を一か所にまとめることが出来るのではと考えこのような実装を行った。

vueのplugin機構を使っているのでpluginsというディレクトリを掘りましたが、今後voicevox自体がplugin機構みたいのを実装したらディレクトリ名が被ってどうかなと思ったので、この辺りの塩梅のレビューもお願いしたいです。