### PR TITLE
Quasarのスタイルが重複して適用されていたのを修正

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import { ipcMessageReceiver } from "./plugins/ipcMessageReceiverPlugin";
 import { Quasar, Dialog, Loading } from "quasar";
 import iconSet from "quasar/icon-set/material-icons";
 import "@quasar/extras/material-icons/material-icons.css";
+import "quasar/dist/quasar.sass";
 import "./styles/_index.scss";
 
 createApp(App)

--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -1,5 +1,3 @@
-@import '~quasar/dist/quasar.sass';
-
 $primary: #a5d4ad;
 $secondary: #212121;
 


### PR DESCRIPTION
今までQuasarのスタイルは `_index.scss` で読み込んでいましたが、これを複数のvueファイルで呼んでいたため、重複して適用されていました
見た目上は問題ありませんが、DevToolsで見た時に同じスタイルが複数適用されていて邪魔だったので1度だけ読み込まれるようにしました