### PR TITLE
Undoヒストリが正しく積まれない/壊れる問題の修正

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -133,7 +133,6 @@ export default defineComponent({
 
     // TODO: change audio textにしてvuexに載せ替える
     const setAudioText = async (text: string) => {
-      console.log(text);
       await store.dispatch(SET_AUDIO_TEXT, { audioKey: props.audioKey, text });
     };
     const updateAudioQuery = async () => {

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -280,13 +280,6 @@ export default defineComponent({
       hoverFlag.value = false;
     };
 
-    // 初期化
-    onMounted(() => {
-      if (audioItem.value.query == undefined) {
-        store.dispatch(FETCH_AUDIO_QUERY, { audioKey: props.audioKey });
-      }
-    });
-
     return {
       characterInfos,
       audioItem,

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -40,9 +40,10 @@
       hide-bottom-space
       class="full-width"
       :disable="uiLocked"
-      :error="inputAudioText.text.length >= 80"
-      v-model="inputAudioText.text"
-      @change="willRemove || setAudioText()"
+      :error="audioItem.text.length >= 80"
+      :model-value="audioItem.text"
+      @update:model-value="setAudioText"
+      @change="willRemove || updateAudioQuery($event)"
       @paste="pasteOnAudioCell"
       @focus="setActiveAudioKey()"
       @keydown.shift.delete.exact="removeCell"
@@ -71,7 +72,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, reactive, ref, watch } from "vue";
+import { computed, defineComponent, ref } from "vue";
 import { useStore } from "@/store";
 import {
   FETCH_ACCENT_PHRASES,
@@ -130,23 +131,12 @@ export default defineComponent({
       URL.createObjectURL(selectedCharacterInfo.value?.iconBlob)
     );
 
-    const storedAudioText = computed(
-      () => store.state.audioItems[props.audioKey].text
-    );
-    const inputAudioText = reactive({
-      text: storedAudioText.value,
-    });
-    watch(storedAudioText, (current, prev) => {
-      if (current !== prev) {
-        inputAudioText.text = current;
-      }
-    });
     // TODO: change audio textにしてvuexに載せ替える
-    const setAudioText = async () => {
-      await store.dispatch(SET_AUDIO_TEXT, {
-        audioKey: props.audioKey,
-        text: inputAudioText.text,
-      });
+    const setAudioText = async (text: string) => {
+      console.log(text);
+      await store.dispatch(SET_AUDIO_TEXT, { audioKey: props.audioKey, text });
+    };
+    const updateAudioQuery = async () => {
       if (!haveAudioQuery.value) {
         store.dispatch(FETCH_AUDIO_QUERY, { audioKey: props.audioKey });
       } else {
@@ -190,8 +180,8 @@ export default defineComponent({
           if (audioItem.value.text == "") {
             const text = texts.shift();
             if (text == undefined) return;
-            inputAudioText.text = text;
-            setAudioText();
+            setAudioText(text);
+            updateAudioQuery();
           }
 
           store.dispatch(PUT_TEXTS, {
@@ -304,9 +294,8 @@ export default defineComponent({
       nowGenerating,
       selectedCharacterInfo,
       characterIconUrl,
-      storedAudioText,
-      inputAudioText,
       setAudioText,
+      updateAudioQuery,
       changeCharacterIndex,
       setActiveAudioKey,
       save,

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -41,7 +41,7 @@
       class="full-width"
       :disable="uiLocked"
       :error="audioItem.text.length >= 80"
-      v-model="audioItem.text"
+      :model-value="audioItem.text"
       @change="willRemove || setAudioText($event)"
       @paste="pasteOnAudioCell"
       @focus="setActiveAudioKey()"

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -663,6 +663,7 @@ export const audioStore = {
       ) => {
         const arrLen = texts.length;
         characterIndex == undefined ? 0 : characterIndex;
+        const addedAudioKeys = [];
         for (let i = 0; i < arrLen; i++) {
           if (texts[i] != "") {
             const audioItem = {
@@ -673,8 +674,15 @@ export const audioStore = {
               audioItem: audioItem,
               prevAudioKey: prevAudioKey,
             });
+            addedAudioKeys.push(prevAudioKey);
           }
         }
+
+        return Promise.all(
+          addedAudioKeys.map((audioKey) =>
+            dispatch(FETCH_AUDIO_QUERY, { audioKey })
+          )
+        );
       }
     ),
     [OPEN_TEXT_EDIT_CONTEXT_MENU]() {


### PR DESCRIPTION
#116 を他の方が担当されそうと言うことで、楽が出来るようこちらで直していた部分を上げておきます。
修正したのは、

* テキスト編集時、`v-model`でTwo-Wayバインディングされていたために`produceWithPatches`で返ってくるPatchが空になっていた問題の修正
* AudioCellの初期化処理で`FETCH_AUDIO_QUERY`をdispatchしていたためにRedoでセルの追加を戻すと以降のヒストリが消える(FETCH_AUDIO_QUERYによってヒストリが上書きされてしまう)問題の修正

の2点になります。

この修正により、一部動作が変わり、

* Enterを押したり、フォーカスを外さなくてもアクセントの生成が行われる
  * 逆にこれらの操作ではアクセントの生成は行われなくなる
* AudioCell追加時には`FETCH_AUDIO_QUERY`はdispatchされず、`setAudioText`の呼び出し、または`PUT_TEXTS`がdispatchされるまで`audioItem.value.query`は空のまま
  * `PUT_TEXTS`は最後にまとめて`FETCH_AUDIO_QUERY`をdispatchするように

となります。
使用感が若干変わるのと、AudioCell周りのUndo/Redoの実装の仕方が変わるため、逆に障害になりそうであればCloseしていただいて問題ありません