### PR TITLE
環境変数の統合および拡張機能の有効化

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -7,7 +7,7 @@ import Store from "electron-store";
 
 import { app, protocol, BrowserWindow, ipcMain, dialog, shell } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
-import installExtension, { VUEJS_DEVTOOLS } from "electron-devtools-installer";
+import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
 
 import path from "path";
 import { textEditContextMenu } from "./electron/contextMenu";
@@ -126,9 +126,6 @@ async function createWindow() {
     height: 600,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
-
-      enableRemoteModule: !!process.env.IS_TEST,
-
       nodeIntegration: true,
       contextIsolation: true,
     },
@@ -308,9 +305,9 @@ app.on("activate", () => {
 });
 
 app.on("ready", async () => {
-  if (isDevelopment && !process.env.IS_TEST) {
+  if (isDevelopment) {
     try {
-      await installExtension(VUEJS_DEVTOOLS);
+      await installExtension(VUEJS3_DEVTOOLS);
     } catch (e) {
       console.error("Vue Devtools failed to install:", e.toString());
     }


### PR DESCRIPTION
環境変数に`NODE_ENV`と`IS_TEST`の似たような役割の変数が存在したので統合しました。
また、`electron`のdeprecatedに指定されている機能である[`RemoteModule`](https://www.electronjs.org/docs/api/remote)が使用されていなかったので無効化しました。
ロードする拡張機能をVue2用のものからVue3用へと差し替えました。この変更により開発者ツールのタブからViewに提供されている情報を見ることができるようになります。
![image](https://user-images.githubusercontent.com/51497552/130297392-133c2e7b-25c5-482c-a83c-5a3a56fe5046.png)
