### PR TITLE
ipcの型をより厳格に

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -5,13 +5,14 @@ import dotenv from "dotenv";
 import treeKill from "tree-kill";
 import Store from "electron-store";
 
-import { app, protocol, BrowserWindow, ipcMain, dialog, shell } from "electron";
+import { app, protocol, BrowserWindow, dialog, shell } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
 
 import path from "path";
 import { textEditContextMenu } from "./electron/contextMenu";
 import { hasSupportedGpu } from "./electron/device";
+import { ipcMainHandle, ipcMainSend } from "@/electron/ipc";
 
 import fs from "fs";
 import { CharacterInfo, Encoding } from "./type/preload";
@@ -145,12 +146,13 @@ async function createWindow() {
   win.webContents.once("did-finish-load", () => {
     if (process.argv.length >= 2) {
       const filePath = process.argv[1];
-      win.webContents.send("LOAD_PROJECT_FILE", { filePath, confirm: false });
+      ipcMainSend(win, "LOAD_PROJECT_FILE", { filePath, confirm: false });
     }
   });
 }
 
-ipcMain.handle("GET_APP_INFOS", () => {
+// プロセス間通信
+ipcMainHandle("GET_APP_INFOS", () => {
   const name = app.getName();
   const version = app.getVersion();
   return {
@@ -159,28 +161,27 @@ ipcMain.handle("GET_APP_INFOS", () => {
   };
 });
 
-// プロセス間通信
-ipcMain.handle("GET_TEMP_DIR", () => {
+ipcMainHandle("GET_TEMP_DIR", () => {
   return tempDir;
 });
 
-ipcMain.handle("GET_CHARACTER_INFOS", () => {
+ipcMainHandle("GET_CHARACTER_INFOS", () => {
   return characterInfos;
 });
 
-ipcMain.handle("GET_POLICY_TEXT", () => {
+ipcMainHandle("GET_POLICY_TEXT", () => {
   return policyText;
 });
 
-ipcMain.handle("GET_OSS_LICENSES", () => {
+ipcMainHandle("GET_OSS_LICENSES", () => {
   return ossLicenses;
 });
 
-ipcMain.handle("GET_UPDATE_INFOS", () => {
+ipcMainHandle("GET_UPDATE_INFOS", () => {
   return updateInfos;
 });
 
-ipcMain.handle("SHOW_AUDIO_SAVE_DIALOG", (event, { title, defaultPath }) => {
+ipcMainHandle("SHOW_AUDIO_SAVE_DIALOG", (_, { title, defaultPath }) => {
   return dialog.showSaveDialogSync(win, {
     title,
     defaultPath,
@@ -189,14 +190,14 @@ ipcMain.handle("SHOW_AUDIO_SAVE_DIALOG", (event, { title, defaultPath }) => {
   });
 });
 
-ipcMain.handle("SHOW_OPEN_DIRECTORY_DIALOG", (event, { title }) => {
+ipcMainHandle("SHOW_OPEN_DIRECTORY_DIALOG", (_, { title }) => {
   return dialog.showOpenDialogSync(win, {
     title,
     properties: ["openDirectory", "createDirectory"],
   })?.[0];
 });
 
-ipcMain.handle("SHOW_PROJECT_SAVE_DIALOG", (event, { title }) => {
+ipcMainHandle("SHOW_PROJECT_SAVE_DIALOG", (_, { title }) => {
   return dialog.showSaveDialogSync(win, {
     title,
     filters: [{ name: "VOICEVOX Project file", extensions: ["vvproj"] }],
@@ -204,7 +205,7 @@ ipcMain.handle("SHOW_PROJECT_SAVE_DIALOG", (event, { title }) => {
   });
 });
 
-ipcMain.handle("SHOW_PROJECT_LOAD_DIALOG", (event, { title }) => {
+ipcMainHandle("SHOW_PROJECT_LOAD_DIALOG", (_, { title }) => {
   return dialog.showOpenDialogSync(win, {
     title,
     filters: [{ name: "VOICEVOX Project file", extensions: ["vvproj"] }],
@@ -212,7 +213,7 @@ ipcMain.handle("SHOW_PROJECT_LOAD_DIALOG", (event, { title }) => {
   });
 });
 
-ipcMain.handle("SHOW_CONFIRM_DIALOG", (event, { title, message }) => {
+ipcMainHandle("SHOW_CONFIRM_DIALOG", (_, { title, message }) => {
   return dialog
     .showMessageBox(win, {
       type: "info",
@@ -225,7 +226,7 @@ ipcMain.handle("SHOW_CONFIRM_DIALOG", (event, { title, message }) => {
     });
 });
 
-ipcMain.handle("SHOW_WARNING_DIALOG", (event, { title, message }) => {
+ipcMainHandle("SHOW_WARNING_DIALOG", (_, { title, message }) => {
   return dialog.showMessageBox(win, {
     type: "warning",
     title: title,
@@ -233,7 +234,7 @@ ipcMain.handle("SHOW_WARNING_DIALOG", (event, { title, message }) => {
   });
 });
 
-ipcMain.handle("SHOW_ERROR_DIALOG", (event, { title, message }) => {
+ipcMainHandle("SHOW_ERROR_DIALOG", (_, { title, message }) => {
   return dialog.showMessageBox(win, {
     type: "error",
     title: title,
@@ -241,7 +242,7 @@ ipcMain.handle("SHOW_ERROR_DIALOG", (event, { title, message }) => {
   });
 });
 
-ipcMain.handle("SHOW_IMPORT_FILE_DIALOG", (event, { title }) => {
+ipcMainHandle("SHOW_IMPORT_FILE_DIALOG", (_, { title }) => {
   return dialog.showOpenDialogSync(win, {
     title,
     filters: [{ name: "Text", extensions: ["txt"] }],
@@ -249,11 +250,11 @@ ipcMain.handle("SHOW_IMPORT_FILE_DIALOG", (event, { title }) => {
   })?.[0];
 });
 
-ipcMain.handle("OPEN_TEXT_EDIT_CONTEXT_MENU", () => {
+ipcMainHandle("OPEN_TEXT_EDIT_CONTEXT_MENU", () => {
   textEditContextMenu.popup({ window: win });
 });
 
-ipcMain.handle("USE_GPU", (_, { newValue }) => {
+ipcMainHandle("USE_GPU", (_, { newValue }) => {
   if (newValue !== undefined) {
     store.set("useGpu", newValue);
   }
@@ -261,11 +262,11 @@ ipcMain.handle("USE_GPU", (_, { newValue }) => {
   return store.get("useGpu", false) as boolean;
 });
 
-ipcMain.handle("IS_AVAILABLE_GPU_MODE", () => {
+ipcMainHandle("IS_AVAILABLE_GPU_MODE", () => {
   return hasSupportedGpu();
 });
 
-ipcMain.handle("FILE_ENCODING", (_, { newValue }) => {
+ipcMainHandle("FILE_ENCODING", (_, { newValue }) => {
   if (newValue !== undefined) {
     store.set("fileEncoding", newValue);
   }

--- a/src/electron/ipc.ts
+++ b/src/electron/ipc.ts
@@ -1,0 +1,28 @@
+import { ipcMain, IpcMainInvokeEvent, BrowserWindow } from "electron";
+
+export function ipcMainHandle<T extends keyof IpcIHData>(
+  channel: T,
+  listener: (
+    event: IpcMainInvokeEvent,
+    ...args: IpcIHData[T]["args"]
+  ) => IpcIHData[T]["return"] | Promise<IpcIHData[T]["return"]>
+): void;
+export function ipcMainHandle(
+  channel: string,
+  listener: (event: IpcMainInvokeEvent, ...args: unknown[]) => unknown
+): void {
+  ipcMain.handle(channel, listener);
+}
+
+export function ipcMainSend<T extends keyof IpcSOData>(
+  win: BrowserWindow,
+  channel: T,
+  ...args: IpcSOData[T]["args"]
+): void;
+export function ipcMainSend(
+  win: BrowserWindow,
+  channel: string,
+  ...args: unknown[]
+): void {
+  return win.webContents.send(channel, ...args);
+}

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -1,77 +1,101 @@
-import { contextBridge, ipcRenderer } from "electron";
+import {
+  contextBridge,
+  ipcRenderer,
+  IpcRenderer,
+  IpcRendererEvent,
+} from "electron";
 import fs from "fs";
 import path from "path";
 
 import { Sandbox } from "@/type/preload";
 
+function ipcRendererInvoke<T extends keyof IpcIHData>(
+  channel: T,
+  ...args: IpcIHData[T]["args"]
+): Promise<IpcIHData[T]["return"]>;
+function ipcRendererInvoke(channel: string, ...args: unknown[]): unknown {
+  return ipcRenderer.invoke(channel, ...args);
+}
+
+function ipcRendererOn<T extends keyof IpcSOData>(
+  channel: T,
+  listener: (event: IpcRendererEvent, ...args: IpcSOData[T]["args"]) => void
+): IpcRenderer;
+function ipcRendererOn(
+  channel: string,
+  listener: (event: IpcRendererEvent, ...args: unknown[]) => void
+) {
+  return ipcRenderer.on(channel, listener);
+}
+
 let tempDir: string;
 
 const api: Sandbox = {
   getAppInfos: async () => {
-    return await ipcRenderer.invoke("GET_APP_INFOS");
+    return await ipcRendererInvoke("GET_APP_INFOS");
   },
 
   getCharacterInfos: async () => {
-    return await ipcRenderer.invoke("GET_CHARACTER_INFOS");
+    return await ipcRendererInvoke("GET_CHARACTER_INFOS");
   },
 
   getPolicyText: async () => {
-    return await ipcRenderer.invoke("GET_POLICY_TEXT");
+    return await ipcRendererInvoke("GET_POLICY_TEXT");
   },
 
   getOssLicenses: async () => {
-    return await ipcRenderer.invoke("GET_OSS_LICENSES");
+    return await ipcRendererInvoke("GET_OSS_LICENSES");
   },
 
   getUpdateInfos: async () => {
-    return await ipcRenderer.invoke("GET_UPDATE_INFOS");
+    return await ipcRendererInvoke("GET_UPDATE_INFOS");
   },
 
   saveTempAudioFile: async ({ relativePath, buffer }) => {
     if (!tempDir) {
-      tempDir = await ipcRenderer.invoke("GET_TEMP_DIR");
+      tempDir = await ipcRendererInvoke("GET_TEMP_DIR");
     }
     fs.writeFileSync(path.join(tempDir, relativePath), new DataView(buffer));
   },
 
   loadTempFile: async () => {
     if (!tempDir) {
-      tempDir = await ipcRenderer.invoke("GET_TEMP_DIR");
+      tempDir = await ipcRendererInvoke("GET_TEMP_DIR");
     }
     const buf = fs.readFileSync(path.join(tempDir, "hoge.txt"));
     return new TextDecoder().decode(buf);
   },
 
   showAudioSaveDialog: ({ title, defaultPath }) => {
-    return ipcRenderer.invoke("SHOW_AUDIO_SAVE_DIALOG", { title, defaultPath });
+    return ipcRendererInvoke("SHOW_AUDIO_SAVE_DIALOG", { title, defaultPath });
   },
 
   showOpenDirectoryDialog: ({ title }) => {
-    return ipcRenderer.invoke("SHOW_OPEN_DIRECTORY_DIALOG", { title });
+    return ipcRendererInvoke("SHOW_OPEN_DIRECTORY_DIALOG", { title });
   },
 
   showProjectSaveDialog: ({ title }) => {
-    return ipcRenderer.invoke("SHOW_PROJECT_SAVE_DIALOG", { title });
+    return ipcRendererInvoke("SHOW_PROJECT_SAVE_DIALOG", { title });
   },
 
   showProjectLoadDialog: ({ title }) => {
-    return ipcRenderer.invoke("SHOW_PROJECT_LOAD_DIALOG", { title });
+    return ipcRendererInvoke("SHOW_PROJECT_LOAD_DIALOG", { title });
   },
 
   showConfirmDialog: ({ title, message }) => {
-    return ipcRenderer.invoke("SHOW_CONFIRM_DIALOG", { title, message });
+    return ipcRendererInvoke("SHOW_CONFIRM_DIALOG", { title, message });
   },
 
   showWarningDialog: ({ title, message }) => {
-    return ipcRenderer.invoke("SHOW_WARNING_DIALOG", { title, message });
+    return ipcRendererInvoke("SHOW_WARNING_DIALOG", { title, message });
   },
 
   showErrorDialog: ({ title, message }) => {
-    return ipcRenderer.invoke("SHOW_ERROR_DIALOG", { title, message });
+    return ipcRendererInvoke("SHOW_ERROR_DIALOG", { title, message });
   },
 
   showImportFileDialog: ({ title }) => {
-    return ipcRenderer.invoke("SHOW_IMPORT_FILE_DIALOG", { title });
+    return ipcRendererInvoke("SHOW_IMPORT_FILE_DIALOG", { title });
   },
 
   writeFile: ({ filePath, buffer }) => {
@@ -83,23 +107,23 @@ const api: Sandbox = {
   },
 
   openTextEditContextMenu: () => {
-    return ipcRenderer.invoke("OPEN_TEXT_EDIT_CONTEXT_MENU");
+    return ipcRendererInvoke("OPEN_TEXT_EDIT_CONTEXT_MENU");
   },
 
   useGpu: (newValue) => {
-    return ipcRenderer.invoke("USE_GPU", { newValue });
+    return ipcRendererInvoke("USE_GPU", { newValue });
   },
 
   isAvailableGPUMode: () => {
-    return ipcRenderer.invoke("IS_AVAILABLE_GPU_MODE");
+    return ipcRendererInvoke("IS_AVAILABLE_GPU_MODE");
   },
 
   fileEncoding: (newValue) => {
-    return ipcRenderer.invoke("FILE_ENCODING", { newValue });
+    return ipcRendererInvoke("FILE_ENCODING", { newValue });
   },
 
   onReceivedIPCMsg: (channel, callback) => {
-    return ipcRenderer.on(channel, callback);
+    return ipcRendererOn(channel, callback);
   },
 };
 

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -64,12 +64,12 @@ type IpcIHData = {
 
   SHOW_WARNING_DIALOG: {
     args: [obj: { title: string; message: string }];
-    return: void;
+    return: Electron.MessageBoxReturnValue;
   };
 
   SHOW_ERROR_DIALOG: {
     args: [obj: { title: string; message: string }];
-    return: void;
+    return: Electron.MessageBoxReturnValue;
   };
 
   OPEN_TEXT_EDIT_CONTEXT_MENU: {
@@ -102,37 +102,3 @@ type IpcSOData = {
     return: void;
   };
 };
-
-declare namespace Electron {
-  interface IpcMain {
-    handle<T extends keyof IpcIHData>(
-      channel: T,
-      listener: (
-        event: IpcMainInvokeEvent,
-        ...args: IpcIHData[T]["args"]
-      ) => IpcIHData[T]["return"] | Promise<IpcIHData[T]["return"]>
-    ): void;
-  }
-
-  interface IpcRenderer {
-    invoke<T extends keyof IpcIHData>(
-      channel: T,
-      ...args: IpcIHData[T]["args"]
-    ): Promise<IpcIHData[T]["return"]>;
-
-    on<T extends keyof IpcSOData>(
-      channel: T,
-      listener: (
-        event: import("electron").IpcRendererEvent,
-        ...args: IpcSOData[T]["args"]
-      ) => void
-    ): this;
-  }
-
-  interface WebContents {
-    send<T extends keyof IpcSOData>(
-      channel: T,
-      ...args: IpcSOData[T]["args"]
-    ): void;
-  }
-}

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -16,8 +16,14 @@ export interface Sandbox {
   showProjectSaveDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
   showConfirmDialog(obj: { title: string; message: string }): Promise<boolean>;
-  showWarningDialog(obj: { title: string; message: string }): Promise<void>;
-  showErrorDialog(obj: { title: string; message: string }): Promise<void>;
+  showWarningDialog(obj: {
+    title: string;
+    message: string;
+  }): Promise<Electron.MessageBoxReturnValue>;
+  showErrorDialog(obj: {
+    title: string;
+    message: string;
+  }): Promise<Electron.MessageBoxReturnValue>;
   showImportFileDialog(obj: { title: string }): Promise<string | undefined>;
   writeFile(obj: { filePath: string; buffer: ArrayBuffer }): void;
   readFile(obj: { filePath: string }): Promise<ArrayBuffer>;
@@ -25,10 +31,10 @@ export interface Sandbox {
   useGpu(newValue?: boolean): Promise<boolean>;
   isAvailableGPUMode(): Promise<boolean>;
   fileEncoding(newValue?: Encoding): Promise<Encoding>;
-  onReceivedIPCMsg: <T extends keyof IpcSOData>(
+  onReceivedIPCMsg<T extends keyof IpcSOData>(
     channel: T,
     listener: (event: IpcRendererEvent, ...args: IpcSOData[T]["args"]) => void
-  ) => IpcRenderer;
+  ): IpcRenderer;
 }
 
 export type AppInfos = {


### PR DESCRIPTION
今までの実装では元からある関数のオーバーロードを足す形で実装していたため、想定外の使われ方をしてもエラーにならず元の型が適用されてanyになるだけでした

TypeScriptの仕様上既存の型を完全に上書きすることは困難であるため、ラッパー関数を作りました

![image](https://user-images.githubusercontent.com/25514849/130314285-88ab4a26-e517-4da4-adff-7a7b13965725.png)
