### PR TITLE
ウィンドウボーダーを変数で持つ

### DIFF
--- a/src/styles/_index.scss
+++ b/src/styles/_index.scss
@@ -1,6 +1,8 @@
 $primary: #a5d4ad;
 $secondary: #212121;
 
+$window-border-width: 2px;
+
 $header-height: 66px;
 $menubar-height: 24px;
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -405,9 +405,9 @@ export default defineComponent({
 @use '@/styles' as global;
 body {
   user-select: none;
-  border-left: solid 2px #{global.$primary};
-  border-right: solid 2px #{global.$primary};
-  border-bottom: solid 4px #{global.$primary};
+  border-left: solid #{global.$window-border-width} #{global.$primary};
+  border-right: solid #{global.$window-border-width} #{global.$primary};
+  border-bottom: solid #{global.$window-border-width} #{global.$primary};
 }
 
 .relarive-absolute-wrapper {
@@ -451,7 +451,10 @@ body {
   display: flex;
 
   .q-splitter--horizontal {
-    height: calc(100vh - #{global.$menubar-height} - #{global.$header-height});
+    height: calc(
+      100vh - #{global.$menubar-height + global.$header-height +
+        global.$window-border-width}
+    );
   }
 }
 


### PR DESCRIPTION
ウィンドウボーダー幅を変数で持ち、ずれていた分を修正しました
左右が2pxだったのに対しbottomだけ4pxだったのが気になったので2pxに揃えました
何か理由があって4pxになっていたのであれば戻します