### PR TITLE
メニュー中のホットキーを登録・プロジェクトの保存周りの機能追加

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -10,7 +10,10 @@
       @mouseover="reassignSubMenuOpen(i)"
     />
     <q-space />
-    <div class="window-title">VOICEVOX</div>
+    <div v-if="projectName !== undefined" class="window-title">
+      {{ projectName + " - VOICEVOX" }}
+    </div>
+    <div v-else class="window-title">VOICEVOX</div>
     <q-space />
     <title-bar-buttons />
   </q-bar>
@@ -21,7 +24,11 @@ import { defineComponent, ref, computed, ComputedRef } from "vue";
 import { useQuasar } from "quasar";
 import { useStore } from "@/store";
 import { UI_LOCKED, SET_USE_GPU, SET_FILE_ENCODING } from "@/store/ui";
-import { SAVE_PROJECT_FILE, LOAD_PROJECT_FILE } from "@/store/project";
+import {
+  SAVE_PROJECT_FILE,
+  LOAD_PROJECT_FILE,
+  PROJECT_NAME,
+} from "@/store/project";
 import { GENERATE_AND_SAVE_ALL_AUDIO, IMPORT_FROM_FILE } from "@/store/audio";
 import MenuButton from "@/components/MenuButton.vue";
 import TitleBarButtons from "@/components/TitleBarButtons.vue";
@@ -69,6 +76,7 @@ export default defineComponent({
     const $q = useQuasar();
 
     const uiLocked = computed(() => store.getters[UI_LOCKED]);
+    const projectName = computed(() => store.getters[PROJECT_NAME]);
 
     const changeUseGPU = async (useGpu: boolean) => {
       if (store.state.useGpu === useGpu) return;
@@ -249,6 +257,7 @@ export default defineComponent({
 
     return {
       uiLocked,
+      projectName,
       subMenuOpenFlags,
       reassignSubMenuOpen,
       menudata,

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -25,6 +25,7 @@ import { SAVE_PROJECT_FILE, LOAD_PROJECT_FILE } from "@/store/project";
 import { GENERATE_AND_SAVE_ALL_AUDIO, IMPORT_FROM_FILE } from "@/store/audio";
 import MenuButton from "@/components/MenuButton.vue";
 import TitleBarButtons from "@/components/TitleBarButtons.vue";
+import Mousetrap from "mousetrap";
 
 type MenuItemBase<T extends string> = {
   type: T;
@@ -39,6 +40,7 @@ export type MenuItemRoot = MenuItemBase<"root"> & {
 
 export type MenuItemButton = MenuItemBase<"button"> & {
   onClick: () => void;
+  shortCut?: string;
 };
 
 export type MenuItemCheckbox = MenuItemBase<"checkbox"> & {
@@ -126,6 +128,7 @@ export default defineComponent({
           {
             type: "button",
             label: "音声書き出し",
+            shortCut: "Ctrl+E",
             onClick: () => {
               store.dispatch(GENERATE_AND_SAVE_ALL_AUDIO, {
                 encoding: store.state.fileEncoding,
@@ -143,6 +146,7 @@ export default defineComponent({
           {
             type: "button",
             label: "プロジェクト保存",
+            shortCut: "Ctrl+S",
             onClick: () => {
               store.dispatch(SAVE_PROJECT_FILE, {});
             },
@@ -150,6 +154,7 @@ export default defineComponent({
           {
             type: "button",
             label: "プロジェクト読み込み",
+            shortCut: "Ctrl+O",
             onClick: () => {
               store.dispatch(LOAD_PROJECT_FILE, {});
             },
@@ -218,6 +223,21 @@ export default defineComponent({
         subMenuOpenFlags.value = arr;
       }
     };
+
+    // メニューバー中のホットキー有効化
+    const _enableHotKey = (items: any) => {
+      items.forEach((item: MenuItemData) => {
+        if (item.type === "root") {
+          _enableHotKey(item.subMenu);
+          return;
+        }
+        if (item.type === "button" && item.shortCut) {
+          Mousetrap.bind(item.shortCut.toLowerCase(), item.onClick);
+          return;
+        }
+      });
+    };
+    _enableHotKey(menudata.value);
 
     return {
       uiLocked,

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -145,8 +145,16 @@ export default defineComponent({
           { type: "separator" },
           {
             type: "button",
-            label: "プロジェクト保存",
+            label: "プロジェクトを上書き保存",
             shortCut: "Ctrl+S",
+            onClick: () => {
+              store.dispatch(SAVE_PROJECT_FILE, { overwrite: true });
+            },
+          },
+          {
+            type: "button",
+            label: "プロジェクトを名前を付けて保存",
+            shortCut: "Ctrl+Shift+S",
             onClick: () => {
               store.dispatch(SAVE_PROJECT_FILE, {});
             },

--- a/src/components/MenuItem.vue
+++ b/src/components/MenuItem.vue
@@ -40,6 +40,7 @@
     </q-item-section>
 
     <q-item-section>{{ menudata.label }}</q-item-section>
+    <q-item-section side>{{ menudata.shortCut }}</q-item-section>
   </q-item>
 </template>
 

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -66,6 +66,10 @@ const api: Sandbox = {
     return new TextDecoder().decode(buf);
   },
 
+  getBaseName: ({ filePath }) => {
+    return path.basename(filePath);
+  },
+
   showAudioSaveDialog: ({ title, defaultPath }) => {
     return ipcRendererInvoke("SHOW_AUDIO_SAVE_DIALOG", { title, defaultPath });
   },

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -4,7 +4,7 @@ import { createStore, Store, useStore as baseUseStore } from "vuex";
 import { State } from "./type";
 import { commandStore } from "./command";
 import { audioStore } from "./audio";
-import { projectActions } from "./project";
+import { projectStore } from "./project";
 import { uiStore } from "./ui";
 
 export const GET_POLICY_TEXT = "GET_POLICY_TEXT";
@@ -36,19 +36,21 @@ export const store = createStore<State>({
     ...uiStore.getters,
     ...audioStore.getters,
     ...commandStore.getters,
+    ...projectStore.getters,
   },
 
   mutations: {
     ...uiStore.mutations,
     ...audioStore.mutations,
     ...commandStore.mutations,
+    ...projectStore.mutations,
   },
 
   actions: {
     ...uiStore.actions,
     ...audioStore.actions,
     ...commandStore.actions,
-    ...projectActions,
+    ...projectStore.actions,
     [GET_POLICY_TEXT]: async () => {
       return await window.electron.getPolicyText();
     },

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -7,12 +7,18 @@ import Ajv, { JTDDataType } from "ajv/dist/jtd";
 
 export const LOAD_PROJECT_FILE = "LOAD_PROJECT_FILE";
 export const SAVE_PROJECT_FILE = "SAVE_PROJECT_FILE";
+export const PROJECT_NAME = "PROJECT_NAME";
 export const SET_PROJECT_FILEPATH = "SET_PROJECT_FILEPATH";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
 export const projectStore = {
   getters: {
+    [PROJECT_NAME](state) {
+      return state.projectFilePath !== undefined
+        ? window.electron.getBaseName({ filePath: state.projectFilePath })
+        : undefined;
+    },
   },
 
   mutations: {

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,4 +1,4 @@
-import { ActionTree } from "vuex";
+import { StoreOptions } from "vuex";
 import { createUILockAction } from "@/store/ui";
 import { REGISTER_AUDIO_ITEM, REMOVE_ALL_AUDIO_ITEM } from "@/store/audio";
 import { State, AudioItem } from "@/store/type";
@@ -7,142 +7,166 @@ import Ajv, { JTDDataType } from "ajv/dist/jtd";
 
 export const LOAD_PROJECT_FILE = "LOAD_PROJECT_FILE";
 export const SAVE_PROJECT_FILE = "SAVE_PROJECT_FILE";
+export const SET_PROJECT_FILEPATH = "SET_PROJECT_FILEPATH";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
-export const projectActions = {
-  [LOAD_PROJECT_FILE]: createUILockAction(
-    async (
-      context,
-      { filePath, confirm }: { filePath?: string; confirm?: boolean }
-    ) => {
-      if (!filePath) {
-        // Select and load a project File.
-        const ret = await window.electron.showProjectLoadDialog({
-          title: "プロジェクトファイルの選択",
-        });
-        if (ret == undefined || ret?.length == 0) {
-          return;
-        }
-        filePath = ret[0];
-      }
+export const projectStore = {
+  getters: {
+  },
 
-      try {
-        const buf = await window.electron.readFile({ filePath });
-        const text = new TextDecoder("utf-8").decode(buf).trim();
-        const obj = JSON.parse(text);
+  mutations: {
+    [SET_PROJECT_FILEPATH](state, { filePath }: { filePath: string }) {
+      state.projectFilePath = filePath;
+    },
+  },
 
-        // appVersion Validation check
-        if (!("appVersion" in obj && typeof obj.appVersion === "string")) {
-          throw new Error(
-            "The appVersion of the project file should be string"
-          );
-        }
-        const appVersionList = versionTextParse(obj.appVersion);
-        const nowAppInfo = await window.electron.getAppInfos();
-        const nowAppVersionList = versionTextParse(nowAppInfo.version);
-        if (appVersionList == null || nowAppVersionList == null) {
-          throw new Error(
-            'An invalid appVersion format. The appVersion should be in the format "%d.%d.%d'
-          );
+  actions: {
+    [LOAD_PROJECT_FILE]: createUILockAction(
+      async (
+        context,
+        { filePath, confirm }: { filePath?: string; confirm?: boolean }
+      ) => {
+        if (!filePath) {
+          // Select and load a project File.
+          const ret = await window.electron.showProjectLoadDialog({
+            title: "プロジェクトファイルの選択",
+          });
+          if (ret == undefined || ret?.length == 0) {
+            return;
+          }
+          filePath = ret[0];
         }
 
-        // Migration
-        if (appVersionList < [0, 4, 0]) {
-          for (const audioItemsKey in obj.audioItems) {
-            if ("charactorIndex" in obj.audioItems[audioItemsKey]) {
-              obj.audioItems[audioItemsKey].characterIndex =
-                obj.audioItems[audioItemsKey].charactorIndex;
-              delete obj.audioItems[audioItemsKey].charactorIndex;
+        try {
+          const buf = await window.electron.readFile({ filePath });
+          const text = new TextDecoder("utf-8").decode(buf).trim();
+          const obj = JSON.parse(text);
+
+          // appVersion Validation check
+          if (!("appVersion" in obj && typeof obj.appVersion === "string")) {
+            throw new Error(
+              "The appVersion of the project file should be string"
+            );
+          }
+          const appVersionList = versionTextParse(obj.appVersion);
+          const nowAppInfo = await window.electron.getAppInfos();
+          const nowAppVersionList = versionTextParse(nowAppInfo.version);
+          if (appVersionList == null || nowAppVersionList == null) {
+            throw new Error(
+              'An invalid appVersion format. The appVersion should be in the format "%d.%d.%d'
+            );
+          }
+
+          // Migration
+          if (appVersionList < [0, 4, 0]) {
+            for (const audioItemsKey in obj.audioItems) {
+              if ("charactorIndex" in obj.audioItems[audioItemsKey]) {
+                obj.audioItems[audioItemsKey].characterIndex =
+                  obj.audioItems[audioItemsKey].charactorIndex;
+                delete obj.audioItems[audioItemsKey].charactorIndex;
+              }
+            }
+            for (const audioItemsKey in obj.audioItems) {
+              if (obj.audioItems[audioItemsKey].query != null) {
+                obj.audioItems[audioItemsKey].query.volumeScale = 1;
+                obj.audioItems[audioItemsKey].query.prePhonemeLength = 0.1;
+                obj.audioItems[audioItemsKey].query.postPhonemeLength = 0.1;
+                obj.audioItems[audioItemsKey].query.outputSamplingRate =
+                  DEFAULT_SAMPLING_RATE;
+              }
             }
           }
-          for (const audioItemsKey in obj.audioItems) {
-            if (obj.audioItems[audioItemsKey].query != null) {
-              obj.audioItems[audioItemsKey].query.volumeScale = 1;
-              obj.audioItems[audioItemsKey].query.prePhonemeLength = 0.1;
-              obj.audioItems[audioItemsKey].query.postPhonemeLength = 0.1;
-              obj.audioItems[audioItemsKey].query.outputSamplingRate =
-                DEFAULT_SAMPLING_RATE;
-            }
+
+          // Validation check
+          const ajv = new Ajv();
+          const validate = ajv.compile(projectSchema);
+          if (!validate(obj)) {
+            throw validate.errors;
           }
-        }
+          if (!obj.audioKeys.every((audioKey) => audioKey in obj.audioItems)) {
+            throw new Error(
+              "Every audioKey in audioKeys should be a key of audioItems"
+            );
+          }
+          if (
+            !obj.audioKeys.every(
+              (audioKey) => obj.audioItems[audioKey].characterIndex != undefined
+            )
+          ) {
+            throw new Error(
+              'Every audioItem should have a "characterIndex" atrribute.'
+            );
+          }
 
-        // Validation check
-        const ajv = new Ajv();
-        const validate = ajv.compile(projectSchema);
-        if (!validate(obj)) {
-          throw validate.errors;
-        }
-        if (!obj.audioKeys.every((audioKey) => audioKey in obj.audioItems)) {
-          throw new Error(
-            "Every audioKey in audioKeys should be a key of audioItems"
+          if (
+            confirm !== false &&
+            !(await window.electron.showConfirmDialog({
+              title: "警告",
+              message:
+                "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
+                "よろしいですか？",
+            }))
+          ) {
+            return;
+          }
+          await context.dispatch(REMOVE_ALL_AUDIO_ITEM);
+
+          const { audioItems, audioKeys } = obj as ProjectType;
+
+          let prevAudioKey = undefined;
+          for (const audioKey of audioKeys) {
+            const audioItem = audioItems[audioKey];
+            prevAudioKey = await context.dispatch(REGISTER_AUDIO_ITEM, {
+              prevAudioKey,
+              audioItem,
+            });
+          }
+          context.commit(SET_PROJECT_FILEPATH, { filePath });
+        } catch (err) {
+          console.error(err);
+          console.error(
+            `VOICEVOX Project file "${filePath}" is a invalid file.`
           );
-        }
-        if (
-          !obj.audioKeys.every(
-            (audioKey) => obj.audioItems[audioKey].characterIndex != undefined
-          )
-        ) {
-          throw new Error(
-            'Every audioItem should have a "characterIndex" atrribute.'
-          );
-        }
-
-        if (
-          confirm !== false &&
-          !(await window.electron.showConfirmDialog({
-            title: "警告",
-            message:
-              "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
-              "よろしいですか？",
-          }))
-        ) {
-          return;
-        }
-        await context.dispatch(REMOVE_ALL_AUDIO_ITEM);
-
-        const { audioItems, audioKeys } = obj as ProjectType;
-
-        let prevAudioKey = undefined;
-        for (const audioKey of audioKeys) {
-          const audioItem = audioItems[audioKey];
-          prevAudioKey = await context.dispatch(REGISTER_AUDIO_ITEM, {
-            prevAudioKey,
-            audioItem,
+          await window.electron.showErrorDialog({
+            title: "エラー",
+            message: "ファイルフォーマットが正しくありません。",
           });
         }
-      } catch (err) {
-        console.error(err);
-        console.error(`VOICEVOX Project file "${filePath}" is a invalid file.`);
-        await window.electron.showErrorDialog({
-          title: "エラー",
-          message: "ファイルフォーマットが正しくありません。",
-        });
       }
-    }
-  ),
-  [SAVE_PROJECT_FILE]: createUILockAction(async (context) => {
-    // Write the current status to a project file.
-    const ret = await window.electron.showProjectSaveDialog({
-      title: "プロジェクトファイルの選択",
-    });
-    if (ret == undefined) {
-      return;
-    }
-    const filePath = ret;
-
-    const appInfos = await window.electron.getAppInfos();
-    const { audioItems, audioKeys } = context.state;
-    const projectData: ProjectType = {
-      appVersion: appInfos.version,
-      audioKeys,
-      audioItems,
-    };
-    const buf = new TextEncoder().encode(JSON.stringify(projectData)).buffer;
-    window.electron.writeFile({ filePath, buffer: buf });
-    return;
-  }),
-} as ActionTree<State, State>;
+    ),
+    [SAVE_PROJECT_FILE]: createUILockAction(
+      async (context, { overwrite }: { overwrite?: boolean }) => {
+        let filePath = context.state.projectFilePath;
+        if (!overwrite || !filePath) {
+          // Write the current status to a project file.
+          const ret = await window.electron.showProjectSaveDialog({
+            title: "プロジェクトファイルの選択",
+          });
+          if (ret == undefined) {
+            return;
+          }
+          filePath = ret;
+        }
+        const appInfos = await window.electron.getAppInfos();
+        const { audioItems, audioKeys } = context.state;
+        const projectData: ProjectType = {
+          appVersion: appInfos.version,
+          audioKeys,
+          audioItems,
+        };
+        const buf = new TextEncoder().encode(
+          JSON.stringify(projectData)
+        ).buffer;
+        window.electron.writeFile({ filePath, buffer: buf });
+        if (!context.state.projectFilePath) {
+          context.commit(SET_PROJECT_FILEPATH, { filePath });
+        }
+        return;
+      }
+    ),
+  },
+} as StoreOptions<State>;
 
 const moraSchema = {
   properties: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -24,6 +24,7 @@ export type State = {
   isHelpDialogOpen: boolean;
   fileEncoding: Encoding;
   isMaximized: boolean;
+  projectFilePath?: string;
 };
 
 export type AudioItem = {

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -8,6 +8,7 @@ export interface Sandbox {
   getUpdateInfos(): Promise<Record<string, any>[]>;
   saveTempAudioFile(obj: { relativePath: string; buffer: ArrayBuffer }): void;
   loadTempFile(): Promise<string>;
+  getBaseName(obj: { filePath: string }): string;
   showAudioSaveDialog(obj: {
     title: string;
     defaultPath?: string;


### PR DESCRIPTION
Resolve #118 
related to #69 

メニュー中のボタンにhotkey割り当てを登録できるようにした (`MenuItemButton.shortCut?`)

* Ctrl+Sで上書き保存（新しいプロジェクトならダイアログを開く）
* Ctrl+Shift+Sで名前を付けて保存（今までのダイアログ開いて保存するやつ）
* Ctrl+Eで音声エクスポート
* Ctrl+Oでプロジェクトファイルを開く

タイトルバーに今開いているプロジェクトファイル名を表示する（Undo/Redoが出来ればそれにフックして未保存のマーク付けたり #117 のフラグにしたり）