### PR TITLE
インストーラーの挙動を改善する

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -7,6 +7,8 @@
     download:
     inetc::get /POPUP "https://github.com/" /RESUME "" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.0" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.0" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.1" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.1" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.2" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.2" /END
     Pop $0 ; return value("OK", "Cancelled" or else)
+
+    ; cancel handling
     ${if} $0 == "Cancelled"
         Quit ; quit immidiately
     ${endif}
@@ -17,21 +19,26 @@
         Pop $0 ; return value("OK", "Cancelled" or else)
     ${endif}
 
+    ; cancel handling
     ${if} $0 == "Cancelled"
         Quit ; quit immidiately
     ${endif}
 
+    ; download error handling
     ${if} $0 != "OK"
         MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Error happened downloading files." IDRETRY download
         Quit ; quit immidiately
     ${endif}
 
+    ; show preparing message banner
+    Banner::show /set 76 "Preparing for installation" "please wait..."
+
     ; copy and concatenate files
-    MessageBox MB_OK "Concatenate files. Please wait."
     nsExec::ExecToStack '"$SYSDIR\cmd.exe" /C COPY /B "$TEMP\voicevox-${VERSION}-x64.nsis.7z.0" + "$TEMP\voicevox-${VERSION}-x64.nsis.7z.1" + "$TEMP\voicevox-${VERSION}-x64.nsis.7z.2" "$EXEDIR\voicevox-${VERSION}-x64.nsis.7z"'
     Pop $0 ; return value
     Pop $1 ; return message
 
+    ; concatenation error handling
     ${If} $0 != "0"
         MessageBox MB_OK|MB_ICONEXCLAMATION "Error happened concatenating files. $1($0)"
         Quit ; quit immidiately
@@ -42,6 +49,8 @@
     Delete "$TEMP\voicevox-${VERSION}-x64.nsis.7z.1"
     Delete "$TEMP\voicevox-${VERSION}-x64.nsis.7z.2"
 
+    ; destroy preparing message banner
+    Banner::destroy
 !macroend
 
 ; post install process

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -43,3 +43,9 @@
     Delete "$TEMP\voicevox-${VERSION}-x64.nsis.7z.2"
 
 !macroend
+
+; post install process
+!macro customInstall
+    ; delete file in installer dir
+    Delete "$EXEDIR\voicevox-${VERSION}-x64.nsis.7z"
+!macroend

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,3 +1,4 @@
+; pre install process
 !macro customInit
     ; define download url
     !define DOWNLOAD_URL "https://github.com/Hiroshiba/voicevox/releases/download/${VERSION}"
@@ -5,35 +6,35 @@
     ; download files
     download:
     inetc::get /POPUP "https://github.com/" /RESUME "" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.0" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.0" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.1" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.1" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.2" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.2" /END
-    Pop $0
+    Pop $0 ; return value("OK", "Cancelled" or else)
     ${if} $0 == "Cancelled"
-        Quit
+        Quit ; quit immidiately
     ${endif}
 
     ; try without proxy
     ${if} $0 != "OK"
         inetc::get /NOPROXY /POPUP "https://github.com/" /RESUME "" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.0" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.0" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.1" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.1" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.2" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.2" /END
-        Pop $0
+        Pop $0 ; return value("OK", "Cancelled" or else)
     ${endif}
 
     ${if} $0 == "Cancelled"
-        Quit
+        Quit ; quit immidiately
     ${endif}
 
     ${if} $0 != "OK"
         MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Error happened downloading files. click OK to abort installation." IDRETRY download
-        Quit
+        Quit ; quit immidiately
     ${endif}
 
     ; copy and concatenate files
     MessageBox MB_OK "Concatenate files. Please wait."
     nsExec::ExecToStack '"$SYSDIR\cmd.exe" /C COPY /B "$TEMP\voicevox-${VERSION}-x64.nsis.7z.0" + "$TEMP\voicevox-${VERSION}-x64.nsis.7z.1" + "$TEMP\voicevox-${VERSION}-x64.nsis.7z.2" "$EXEDIR\voicevox-${VERSION}-x64.nsis.7z"'
-    Pop $0
-    Pop $1
+    Pop $0 ; return value
+    Pop $1 ; return message
 
     ${If} $0 != "0"
         MessageBox MB_OK|MB_ICONEXCLAMATION "Error happened concatenating files. $1($0)"
-        Quit
+        Quit ; quit immidiately
     ${EndIf}
 
     ; delete files in temp dir

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -22,7 +22,7 @@
     ${endif}
 
     ${if} $0 != "OK"
-        MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Error happened downloading files. click OK to abort installation." IDRETRY download
+        MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Error happened downloading files." IDRETRY download
         Quit ; quit immidiately
     ${endif}
 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,7 +1,7 @@
 ; pre install process
 !macro customInit
     ; define download url
-    !define DOWNLOAD_URL "https://github.com/Hiroshiba/voicevox/releases/download/${VERSION}"
+    !define DOWNLOAD_URL "https://github.com/HyodaKazuaki/voicevox/releases/download/${VERSION}"
 
     ; download files
     download:
@@ -10,7 +10,7 @@
 
     ; download cancel handling
     ${if} $0 == "Cancelled"
-        Quit ; quit immidiately
+        Quit ; quit immediately
     ${endif}
 
     ; try without proxy
@@ -21,13 +21,13 @@
 
     ; download cancel handling
     ${if} $0 == "Cancelled"
-        Quit ; quit immidiately
+        Quit ; quit immediately
     ${endif}
 
     ; download error handling
     ${if} $0 != "OK"
         MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "Error happened downloading files." IDRETRY download
-        Quit ; quit immidiately
+        Quit ; quit immediately
     ${endif}
 
     ; show preparing message banner
@@ -41,7 +41,7 @@
     ; concatenation error handling
     ${If} $0 != "0"
         MessageBox MB_OK|MB_ICONEXCLAMATION "Error happened concatenating files. $1($0)"
-        Quit ; quit immidiately
+        Quit ; quit immediately
     ${EndIf}
 
     ; delete files in temp dir

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -8,7 +8,7 @@
     inetc::get /POPUP "https://github.com/" /RESUME "" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.0" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.0" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.1" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.1" "${DOWNLOAD_URL}/voicevox-${VERSION}-x64.nsis.7z.2" "$TEMP/voicevox-${VERSION}-x64.nsis.7z.2" /END
     Pop $0 ; return value("OK", "Cancelled" or else)
 
-    ; cancel handling
+    ; download cancel handling
     ${if} $0 == "Cancelled"
         Quit ; quit immidiately
     ${endif}
@@ -19,7 +19,7 @@
         Pop $0 ; return value("OK", "Cancelled" or else)
     ${endif}
 
-    ; cancel handling
+    ; download cancel handling
     ${if} $0 == "Cancelled"
         Quit ; quit immidiately
     ${endif}

--- a/build/splitResources.js
+++ b/build/splitResources.js
@@ -10,7 +10,7 @@ exports.default = async function (buildResult) {
     throw ErrorMessage;
   }
   const segmentSize = 1 * 1024 ** 3; // 1GB
-  const fileName = `voicevox-${projectVersion}-x64.nsis.7z`; // targe file name
+  const fileName = `voicevox-${projectVersion}-x64.nsis.7z`; // target file name
   const targetDirectory = path.resolve(buildResult.outDir, "nsis-web"); // for nsis-web
   const outputDirectory = path.resolve(targetDirectory, "out");
   const inputFile = path.resolve(targetDirectory, fileName);

--- a/build/splitResources.js
+++ b/build/splitResources.js
@@ -52,6 +52,6 @@ exports.default = async function (buildResult) {
   });
 
   inputStream.on("end", () => {
-    console.log("Finished.");
+    console.log("Split Finished.");
   });
 };


### PR DESCRIPTION
#148 で挙げられていたいくつかの気になる挙動をはじめとするいくつかの点を改善しました。

このPRに含まれる改善を行ったインストーラのサンプルを以下のGitHub Releaseで公開していますので、ご確認ください。
https://github.com/HyodaKazuaki/voicevox/releases/tag/0.4.1

# 改善内容
* ファイル分割スクリプトの分割終了メッセージを変更(分割終了であることを明確にした)
* 断片データ(`voicevox-${VERSION}-x64.nsis.7z.0`のこと)のダウンロード失敗時に表示されるエラーメッセージボックスのテキストが正しくない点を修正(OKボタンが存在しないのにOKボタンについて書いてあった)
* ダウンロード後に表示される結合前メッセージボックスを削除
* 断片データ結合中及び削除中に表示される「インストールの準備をしています。」に相当するメッセージバナーを追加
* 結合データをインストール完了後に削除するよう変更
* NSISスクリプトの理解を促進するためのコメントを追加

コメントについては少々冗長かと思うほどありますので、減らすべきであれば指示ください。