### PR TITLE
インストール前にディスクサイズを確認する

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,7 +1,38 @@
-; pre install process
-!macro customInit
+!include "LogicLib.nsh"
+!include "FileFunc.nsh"
+
+!macro defineVariables
     ; define download url
     !define DOWNLOAD_URL "https://github.com/Hiroshiba/voicevox/releases/download/${VERSION}"
+
+    ; 12GB (Installer: 2.7GB x2, VOICEVOX: 5.7GB)
+    !define SPACENEEDED 12
+!macroend
+
+!macro checkDiskSpace
+    Var /GLOBAL spaceAvailable
+
+	${GetRoot} "$INSTDIR" $0 ; get drive letter
+
+	${DriveSpace} "$0\" "/D=F /S=G" $spaceAvailable ; G = GiB
+
+    MessageBox MB_OKCANCEL|MB_ICONQUESTION "VOICEVOX needs to have at least ${SPACENEEDED} GB of free space on your system drive to installation.$\r$\nSpace available: $spaceAvailable GB$\r$\nDo you want to install VOICEVOX?" IDOK next
+    ; execute below process if selected "Cancel"
+    Quit ; quit immediately
+
+    ; execute below process if selected "OK"
+    next:
+    ${If} $spaceAvailable < ${SPACENEEDED}
+        MessageBox MB_OK|MB_ICONEXCLAMATION "There is not enough free space to install VOICEVOX on your system drive.$\r$\nnSpace required: ${SPACENEEDED} GB$\r$\nSpace available: $spaceAvailable GB"
+        Quit ; quit immediately
+    ${EndIf}
+!macroend
+
+; pre install process
+!macro customInit
+    !insertmacro defineVariables
+
+    !insertmacro checkDiskSpace
 
     ; download files
     download:

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -25,14 +25,14 @@
 
     MessageBox MB_OKCANCEL|MB_ICONQUESTION "VOICEVOXをインストールするために ${VOICEVOX_DOWNLOAD_SIZE} GBのファイルをダウンロードします。$\r$\nインストールを続行しますか？" IDOK next
     ; execute below process if selected "Cancel"
-    Quit ; quit immediately
+    !insertmacro quitSuccess ; normal termination immediately
 
     ; execute below process if selected "OK"
     next:
     ${If} $spaceAvailable < ${INSTALL_SPACE_NEEDED}
         MessageBox MB_YESNO|MB_ICONEXCLAMATION "インストール作業には ${INSTALL_SPACE_NEEDED} GBの空き容量が必要です。（空き容量：$spaceAvailable GB）$\r$\nインストールを中断しますか？" IDNO continue
         ; execute below process if select "YES"
-        Quit ; quit immediately
+        !insertmacro quitSuccess ; normal termination immediately
 
         ; execute below process if selected "NO"
         continue:
@@ -52,7 +52,7 @@
 
     ; download cancel handling
     ${if} $0 == "Cancelled"
-        Quit ; quit immediately
+        !insertmacro quitSuccess ; normal termination immediately
     ${endif}
 
     ; try without proxy
@@ -63,7 +63,7 @@
 
     ; download cancel handling
     ${if} $0 == "Cancelled"
-        Quit ; quit immediately
+        !insertmacro quitSuccess ; normal termination immediately
     ${endif}
 
     ; download error handling

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -5,8 +5,15 @@
     ; define download url
     !define DOWNLOAD_URL "https://github.com/Hiroshiba/voicevox/releases/download/${VERSION}"
 
-    ; 12GB (Installer: 2.7GB x2, VOICEVOX: 5.7GB)
-    !define SPACENEEDED 12
+    ; installer size (GB)
+    !define VOICEVOX_DOWNLOAD_SIZE 2.7
+    ; VOICEVOX size (GB)
+    !define VOICEVOX_SIZE 5.7
+    ; space required for installation (including installer x2 and vOICEVOX)
+    ; because of NSIS specification, mathematic operation must be one operation at a command.
+    ; ref. https://nsis.sourceforge.io/mediawiki/index.php?title=Reference/!define&oldid=23418
+    !define /math VOICEVOX_DOWNLOAD_SIZE_DUBLE ${VOICEVOX_DOWNLOAD_SIZE} * 2
+    !define /math INSTALL_SPACE_NEEDED ${VOICEVOX_DOWNLOAD_SIZE_DUBLE} + ${VOICEVOX_SIZE}
 !macroend
 
 !macro checkDiskSpace
@@ -16,15 +23,19 @@
 
     ${DriveSpace} "$0\" "/D=F /S=G" $spaceAvailable ; G = GiB
 
-    MessageBox MB_OKCANCEL|MB_ICONQUESTION "VOICEVOX needs to have at least ${SPACENEEDED} GB of free space on your system drive to installation.$\r$\nSpace available: $spaceAvailable GB$\r$\nDo you want to install VOICEVOX?" IDOK next
+    MessageBox MB_OKCANCEL|MB_ICONQUESTION "VOICEVOXをインストールするために ${VOICEVOX_DOWNLOAD_SIZE} GBのファイルをダウンロードします。$\r$\nインストールを続行しますか？" IDOK next
     ; execute below process if selected "Cancel"
     Quit ; quit immediately
 
     ; execute below process if selected "OK"
     next:
-    ${If} $spaceAvailable < ${SPACENEEDED}
-        MessageBox MB_OK|MB_ICONEXCLAMATION "There is not enough free space to install VOICEVOX on your system drive.$\r$\nnSpace required: ${SPACENEEDED} GB$\r$\nSpace available: $spaceAvailable GB"
+    ${If} $spaceAvailable < ${INSTALL_SPACE_NEEDED}
+        MessageBox MB_YESNO|MB_ICONEXCLAMATION "インストール作業には ${INSTALL_SPACE_NEEDED} GBの空き容量が必要です。（空き容量：$spaceAvailable GB）$\r$\nインストールを中断しますか？" IDNO continue
+        ; execute below process if select "YES"
         Quit ; quit immediately
+
+        ; execute below process if selected "NO"
+        continue:
     ${EndIf}
 !macroend
 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -12,9 +12,9 @@
 !macro checkDiskSpace
     Var /GLOBAL spaceAvailable
 
-	${GetRoot} "$INSTDIR" $0 ; get drive letter
+    ${GetRoot} "$INSTDIR" $0 ; get drive letter
 
-	${DriveSpace} "$0\" "/D=F /S=G" $spaceAvailable ; G = GiB
+    ${DriveSpace} "$0\" "/D=F /S=G" $spaceAvailable ; G = GiB
 
     MessageBox MB_OKCANCEL|MB_ICONQUESTION "VOICEVOX needs to have at least ${SPACENEEDED} GB of free space on your system drive to installation.$\r$\nSpace available: $spaceAvailable GB$\r$\nDo you want to install VOICEVOX?" IDOK next
     ; execute below process if selected "Cancel"

--- a/vue.config.js
+++ b/vue.config.js
@@ -27,7 +27,6 @@ module.exports = {
         productName: "VOICEVOX",
         appId: "jp.hiroshiba.voicevox",
         copyright: "Hiroshiba Kazuyuki",
-        compression: "maximum",
         afterAllArtifactBuild: path.resolve(
           __dirname,
           "build",


### PR DESCRIPTION
close #160

electron-builderで作ることができるNSISインストーラはカスタマイズできるもののエラーハンドリングをすることは難しいです。
特にショートカット作成などの失敗を検知する方法はありません。
そこで、インストール前にディスクの空き容量をチェックする機能を追加しました。

このPRに含まれる改善を行ったインストーラーのサンプルを以下のGitHub Releaseで公開していますので、ご確認ください。
https://github.com/HyodaKazuaki/voicevox/releases/tag/0.4.1

# 内容
* インストール確認/空き容量不足のダイアログを追加
  以下のIssueで記載したように必要な容量と空き容量を表示し、本当にインストールしてよいか確認するダイアログも追加しました。
  https://github.com/Hiroshiba/voicevox/issues/148#issuecomment-904536041
  また、インストール前にシステムドライブの空き容量を取得し、空き容量が明らかに不足している場合はエラーダイアログを発生させるようにしました。
* 圧縮オプションを除去
  インストーラ作成時の圧縮オプションを`maximum`にしていましたが、以下に記載があるように処理時間の割に効果が殆どないため削除しました。
  > `compression` = `normal` “store” | “normal” | “maximum” - The compression level. If you want to rapidly test build, `store` can reduce build time significantly. `maximum` doesn’t lead to noticeable size difference, but increase build time.

  https://www.electron.build/configuration/configuration.html#overridable-per-platform-options


# 制限
インストールに必要な容量は実測して代入する必要があります。
データファイルのダウンロード先リンクとともにスクリプトの最初の方に移動して編集しやすくしました。
https://github.com/Hiroshiba/voicevox/commit/be4b476eb48b50613cf6d04fd256aeaad2c9a358#diff-9509ebc5f256196a628f79001406ea5ab1aab64728fbc20a5501061d1dd31eb9R4-R10

# 議論
* 1つ目のダイアログは必要か
  このPRでは、インストーラに新たに2つダイアログが追加されます。これらのダイアログは冗長かもしれないので、前者のダイアログを削除するか、代わりにVOICEVOX自体が必要とする容量(インストールに必要な容量ではない)を表示してユーザーに確認してもらっても良いかもしれません。
* メッセージを日本語化すべきか
  インストーラで表示されるメッセージはすべて英語です。これを日本語にしてもいいかもしれません。

# 備考
electron-builderでは、`nsi`形式のNSISスクリプトを記述することで1からNSISインストーラを作成することができます。
https://www.electron.build/configuration/nsis.html#NsisOptions-script
これを利用することですべてのエラーハンドリングをすることができます。
しかし、レジストリ周りの操作やアンインストールの設定などを網羅する必要があり、インストーラの維持にかかるコストが大きくなってしまいそうです。
しかし、インストーラを分離できるようになるので、もしかするとデバッグはやりやすくなるかもしれません。