### PR TITLE
リロードのショートカットキーを無効にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,7 @@ import dotenv from "dotenv";
 import treeKill from "tree-kill";
 import Store from "electron-store";
 
-import { app, protocol, BrowserWindow, dialog, shell } from "electron";
+import { app, protocol, BrowserWindow, dialog, Menu, shell } from "electron";
 import { createProtocol } from "vue-cli-plugin-electron-builder/lib";
 import installExtension, { VUEJS3_DEVTOOLS } from "electron-devtools-installer";
 
@@ -164,10 +164,10 @@ async function createWindow() {
       ipcMainSend(win, "LOAD_PROJECT_FILE", { filePath, confirm: false });
     }
   });
+}
 
-  if (!isDevelopment) {
-    win.removeMenu();
-  }
+if (!isDevelopment) {
+  Menu.setApplicationMenu(null);
 }
 
 // プロセス間通信

--- a/src/background.ts
+++ b/src/background.ts
@@ -164,6 +164,8 @@ async function createWindow() {
       ipcMainSend(win, "LOAD_PROJECT_FILE", { filePath, confirm: false });
     }
   });
+
+  win.removeMenu();
 }
 
 // プロセス間通信

--- a/src/background.ts
+++ b/src/background.ts
@@ -165,7 +165,9 @@ async function createWindow() {
     }
   });
 
-  win.removeMenu();
+  if (!isDevelopment) {
+    win.removeMenu();
+  }
 }
 
 // プロセス間通信


### PR DESCRIPTION
#183 

見えていませんがelectronのメニューが存在しているため、そのショートカットキーが機能しているようです。
メニューを明示的に削除することで、リロードできなくなります。