### PR TITLE
アクセントなどを操作したアクセントフレーズ以外のピッチを固定する

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -93,7 +93,7 @@
               "
               @click="
                 uiLocked ||
-                  toggleAccentPhraseSplit(accentPhraseIndex, moraIndex, false)
+                  toggleAccentPhraseSplit(accentPhraseIndex, false, moraIndex)
               "
               :class="[
                 'splitter-cell',
@@ -110,8 +110,7 @@
             <div class="text-cell">{{ accentPhrase.pauseMora.text }}</div>
             <div
               @click="
-                uiLocked ||
-                  toggleAccentPhraseSplit(accentPhraseIndex, null, true)
+                uiLocked || toggleAccentPhraseSplit(accentPhraseIndex, true)
               "
               class="
                 splitter-cell
@@ -213,8 +212,8 @@ export default defineComponent({
 
     const toggleAccentPhraseSplit = (
       accentPhraseIndex: number,
-      moraIndex: number | null,
-      isPause: boolean
+      isPause: boolean,
+      moraIndex?: number
     ) => {
       store.dispatch(CHANGE_ACCENT_PHRASE_SPLIT, {
         audioKey: activeAudioKey.value!,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -498,7 +498,7 @@ export const audioStore = typeAsStoreOptions({
       }
     }),
     async [CHANGE_ACCENT_PHRASE_SPLIT](
-      { dispatch },
+      { state, dispatch },
       {
         audioKey,
         accentPhraseIndex,
@@ -517,7 +517,20 @@ export const audioStore = typeAsStoreOptions({
         moraIndex,
         isPause,
       });
-      return dispatch(FETCH_MORA_DATA, { audioKey });
+      const changeMoraDataIndexes = [accentPhraseIndex];
+      const query = state.audioItems[audioKey].query!;
+      if (
+        (moraIndex ===
+          query.accentPhrases[accentPhraseIndex].moras.length - 1 ||
+          isPause) &&
+        moraIndex !== null
+      ) {
+        changeMoraDataIndexes.push(accentPhraseIndex + 1);
+      }
+      return dispatch(FETCH_MORA_DATA, {
+        audioKey,
+        changeMoraDataIndexes,
+      });
     },
     [SET_AUDIO_MORA_DATA]: oldCreateCommandAction<
       State,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -510,6 +510,10 @@ export const audioStore = typeAsStoreOptions({
         isPause: boolean;
       }
     ) {
+      // 後で同じ条件分岐になるようにするため、TOGGLE_ACCENT_PHRASE_SPLIT内で変更する前のqueryの状態をdeepcopyしておく。
+      const query: AudioQuery = JSON.parse(
+        JSON.stringify(state.audioItems[audioKey].query!)
+      );
       await dispatch(TOGGLE_ACCENT_PHRASE_SPLIT, {
         audioKey,
         accentPhraseIndex,
@@ -517,13 +521,12 @@ export const audioStore = typeAsStoreOptions({
         isPause,
       });
       const changeIndexes = [accentPhraseIndex];
-      const query = state.audioItems[audioKey].query!;
       if (
-        (moraIndex ===
-          query.accentPhrases[accentPhraseIndex].moras.length - 1 ||
-          isPause) &&
+        moraIndex !== query.accentPhrases[accentPhraseIndex].moras.length - 1 &&
+        !isPause &&
         moraIndex !== null
       ) {
+        // split
         changeIndexes.push(accentPhraseIndex + 1);
       }
       return dispatch(FETCH_MORA_DATA, {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -331,8 +331,8 @@ export const audioStore = typeAsStoreOptions({
       { state, dispatch },
       {
         audioKey,
-        changeMoraDataIndexes,
-      }: { audioKey: string; changeMoraDataIndexes?: number[] }
+        changeIndexes,
+      }: { audioKey: string; changeIndexes?: number[] }
     ) {
       const audioItem = state.audioItems[audioKey];
       // "Do not mutate vuex store state outside mutation handlers"エラー回避のための配列コピー
@@ -345,10 +345,9 @@ export const audioStore = typeAsStoreOptions({
             state.characterInfos![audioItem.characterIndex!].metas.speaker,
         })
         .then((accentPhrases) => {
-          if (changeMoraDataIndexes !== undefined) {
-            for (const changeMoraDataIndex of changeMoraDataIndexes) {
-              originAccentPhrases[changeMoraDataIndex] =
-                accentPhrases[changeMoraDataIndex];
+          if (changeIndexes !== undefined) {
+            for (const changeIndex of changeIndexes) {
+              originAccentPhrases[changeIndex] = accentPhrases[changeIndex];
             }
             accentPhrases = originAccentPhrases;
           }
@@ -436,7 +435,7 @@ export const audioStore = typeAsStoreOptions({
       await dispatch(SET_AUDIO_ACCENT, { audioKey, accentPhraseIndex, accent });
       return dispatch(FETCH_MORA_DATA, {
         audioKey,
-        changeMoraDataIndexes: [accentPhraseIndex],
+        changeIndexes: [accentPhraseIndex],
       });
     },
     [TOGGLE_ACCENT_PHRASE_SPLIT]: oldCreateCommandAction<
@@ -517,7 +516,7 @@ export const audioStore = typeAsStoreOptions({
         moraIndex,
         isPause,
       });
-      const changeMoraDataIndexes = [accentPhraseIndex];
+      const changeIndexes = [accentPhraseIndex];
       const query = state.audioItems[audioKey].query!;
       if (
         (moraIndex ===
@@ -525,11 +524,11 @@ export const audioStore = typeAsStoreOptions({
           isPause) &&
         moraIndex !== null
       ) {
-        changeMoraDataIndexes.push(accentPhraseIndex + 1);
+        changeIndexes.push(accentPhraseIndex + 1);
       }
       return dispatch(FETCH_MORA_DATA, {
         audioKey,
-        changeMoraDataIndexes,
+        changeIndexes,
       });
     },
     [SET_AUDIO_MORA_DATA]: oldCreateCommandAction<

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -526,7 +526,7 @@ export const audioStore = typeAsStoreOptions({
         !isPause &&
         moraIndex !== null
       ) {
-        // split
+        // split時はaccentPhraseIndexの後ろのものもMoraPitchをリセットしたいので、+1したindexをリストに追加しておく
         changeIndexes.push(accentPhraseIndex + 1);
       }
       return dispatch(FETCH_MORA_DATA, {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -331,8 +331,8 @@ export const audioStore = typeAsStoreOptions({
       { state, dispatch },
       {
         audioKey,
-        changeMoraDataIndex,
-      }: { audioKey: string; changeMoraDataIndex?: number }
+        changeMoraDataIndexes,
+      }: { audioKey: string; changeMoraDataIndexes?: number[] }
     ) {
       const audioItem = state.audioItems[audioKey];
       // "Do not mutate vuex store state outside mutation handlers"エラー回避のための配列コピー
@@ -345,9 +345,11 @@ export const audioStore = typeAsStoreOptions({
             state.characterInfos![audioItem.characterIndex!].metas.speaker,
         })
         .then((accentPhrases) => {
-          if (changeMoraDataIndex !== undefined) {
-            originAccentPhrases[changeMoraDataIndex] =
-              accentPhrases[changeMoraDataIndex];
+          if (changeMoraDataIndexes !== undefined) {
+            for (const changeMoraDataIndex of changeMoraDataIndexes) {
+              originAccentPhrases[changeMoraDataIndex] =
+                accentPhrases[changeMoraDataIndex];
+            }
             accentPhrases = originAccentPhrases;
           }
           dispatch(SET_ACCENT_PHRASES, { audioKey, accentPhrases });
@@ -434,7 +436,7 @@ export const audioStore = typeAsStoreOptions({
       await dispatch(SET_AUDIO_ACCENT, { audioKey, accentPhraseIndex, accent });
       return dispatch(FETCH_MORA_DATA, {
         audioKey,
-        changeMoraDataIndex: accentPhraseIndex,
+        changeMoraDataIndexes: [accentPhraseIndex],
       });
     },
     [TOGGLE_ACCENT_PHRASE_SPLIT]: oldCreateCommandAction<


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

- [x] アクセント位置変更時に、変更したアクセント句以外のイントネーションを保持する
- [x] アクセント結合時に、結合したアクセント句以外のイントネーションを保持する
- [x] アクセント分割時に、分割したアクセント句以外のイントネーションを保持する

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

related #196

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
![voicevox_move_accent_and_split_join_demo](https://user-images.githubusercontent.com/34832037/133830575-acd13b85-424f-4db3-bf66-2d66dd7d0978.gif)


## その他
Issue内部で述べられている件に関する完全な解決策ではないと思われるため、relatedにしてcloseしないようにしています。
