### PR TITLE
画像をドラッグできないように修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,10 @@ export default defineComponent({
   flex-direction: column;
 }
 
+img {
+  pointer-events: none;
+}
+
 // ホバー色
 .q-hoverable {
   &:hover > .q-focus-helper {


### PR DESCRIPTION
## 内容

画像をドラッグ出来てしまい、そのままエクスプローラーにドロップすると立ち絵画像等がファイルとして取得出来てしまうので、画像をドラッグできないように修正しました

<!-- ## 関連 Issue -->

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

<!-- ## スクリーンショット・動画など -->

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

<!-- ## その他 -->
