### PR TITLE
無音時間のスライダーを追加

### DIFF
--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -77,6 +77,52 @@
         @pan="setPanning(previewAudioVolumeScale, $event)"
       />
     </div>
+    <div class="q-px-md">
+      <span class="text-body1 q-mb-xs"
+        >無音時間（前）
+        {{ previewAudioPrePhonemeLength.currentValue.value.toFixed(2) }}</span
+      >
+      <q-slider
+        dense
+        snap
+        :min="0"
+        :max="2"
+        :step="0.05"
+        :disable="uiLocked"
+        :model-value="previewAudioPrePhonemeLength.currentValue.value"
+        @update:model-value="
+          setPreviewValue(previewAudioPrePhonemeLength, $event)
+        "
+        @change="setAudioPrePhonemeLength"
+        @wheel="
+          uiLocked || setAudioInfoByScroll(query, $event.deltaY, 'prePhoneme')
+        "
+        @pan="setPanning(previewAudioPrePhonemeLength, $event)"
+      />
+    </div>
+    <div class="q-px-md">
+      <span class="text-body1 q-mb-xs"
+        >無音時間（後）
+        {{ previewAudioPostPhonemeLength.currentValue.value.toFixed(2) }}</span
+      >
+      <q-slider
+        dense
+        snap
+        :min="0"
+        :max="2"
+        :step="0.05"
+        :disable="uiLocked"
+        :model-value="previewAudioPostPhonemeLength.currentValue.value"
+        @update:model-value="
+          setPreviewValue(previewAudioPostPhonemeLength, $event)
+        "
+        @change="setAudioPostPhonemeLength"
+        @wheel="
+          uiLocked || setAudioInfoByScroll(query, $event.deltaY, 'postPhoneme')
+        "
+        @pan="setPanning(previewAudioPostPhonemeLength, $event)"
+      />
+    </div>
   </div>
 </template>
 
@@ -89,6 +135,8 @@ import {
   SET_AUDIO_PITCH_SCALE,
   SET_AUDIO_SPEED_SCALE,
   SET_AUDIO_VOLUME_SCALE,
+  SET_AUDIO_PRE_PHONEME_LENGTH,
+  SET_AUDIO_POST_PHONEME_LENGTH,
 } from "@/store/audio";
 import { UI_LOCKED } from "@/store/ui";
 import { AudioQuery } from "@/openapi";
@@ -125,6 +173,14 @@ export default defineComponent({
 
     const previewAudioVolumeScale = new PreviewableValue(
       () => query.value?.volumeScale
+    );
+
+    const previewAudioPrePhonemeLength = new PreviewableValue(
+      () => query.value?.prePhonemeLength
+    );
+
+    const previewAudioPostPhonemeLength = new PreviewableValue(
+      () => query.value?.postPhonemeLength
     );
 
     const setPreviewValue = (
@@ -175,7 +231,29 @@ export default defineComponent({
       });
     };
 
-    type InfoType = "speed" | "pitch" | "into" | "volume";
+    const setAudioPrePhonemeLength = (prePhonemeLength: number) => {
+      previewAudioPrePhonemeLength.stopPreview();
+      store.dispatch(SET_AUDIO_PRE_PHONEME_LENGTH, {
+        audioKey: activeAudioKey.value!,
+        prePhonemeLength,
+      });
+    };
+
+    const setAudioPostPhonemeLength = (postPhonemeLength: number) => {
+      previewAudioPostPhonemeLength.stopPreview();
+      store.dispatch(SET_AUDIO_POST_PHONEME_LENGTH, {
+        audioKey: activeAudioKey.value!,
+        postPhonemeLength,
+      });
+    };
+
+    type InfoType =
+      | "speed"
+      | "pitch"
+      | "into"
+      | "volume"
+      | "prePhoneme"
+      | "postPhoneme";
 
     const setAudioInfoByScroll = (
       query: AudioQuery,
@@ -215,6 +293,24 @@ export default defineComponent({
           }
           break;
         }
+        case "prePhoneme": {
+          let curPrePhoneme =
+            query.prePhonemeLength - (delta_y > 0 ? 0.05 : -0.05);
+          curPrePhoneme = Math.round(curPrePhoneme * 1e2) / 1e2;
+          if (2 >= curPrePhoneme && curPrePhoneme >= 0) {
+            setAudioPrePhonemeLength(curPrePhoneme);
+          }
+          break;
+        }
+        case "postPhoneme": {
+          let curPostPhoneme =
+            query.postPhonemeLength - (delta_y > 0 ? 0.05 : -0.05);
+          curPostPhoneme = Math.round(curPostPhoneme * 1e2) / 1e2;
+          if (2 >= curPostPhoneme && curPostPhoneme >= 0) {
+            setAudioPostPhonemeLength(curPostPhoneme);
+          }
+          break;
+        }
         default:
           break;
       }
@@ -229,11 +325,15 @@ export default defineComponent({
       previewAudioPitchScale,
       previewAudioIntonationScale,
       previewAudioVolumeScale,
+      previewAudioPrePhonemeLength,
+      previewAudioPostPhonemeLength,
       setPreviewValue,
       setAudioSpeedScale,
       setAudioPitchScale,
       setAudioIntonationScale,
       setAudioVolumeScale,
+      setAudioPrePhonemeLength,
+      setAudioPostPhonemeLength,
       setAudioInfoByScroll,
       setPanning,
     };

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -86,6 +86,8 @@ export const SET_AUDIO_QUERY = "SET_AUDIO_QUERY";
 export const FETCH_AUDIO_QUERY = "FETCH_AUDIO_QUERY";
 export const SET_AUDIO_SPEED_SCALE = "SET_AUDIO_SPEED_SCALE";
 export const SET_AUDIO_PITCH_SCALE = "SET_AUDIO_PITCH_SCALE";
+export const SET_AUDIO_PRE_PHONEME_LENGTH = "SET_AUDIO_PRE_PHONEME_LENGTH";
+export const SET_AUDIO_POST_PHONEME_LENGTH = "SET_AUDIO_POST_PHONEME_LENGTH";
 export const SET_AUDIO_INTONATION_SCALE = "SET_AUDIO_INTONATION_SCALE";
 export const SET_AUDIO_VOLUME_SCALE = "SET_AUDIO_VOLUME_SCALE";
 export const SET_AUDIO_ACCENT = "SET_AUDIO_ACCENT";
@@ -373,6 +375,18 @@ export const audioStore = {
       { audioKey: string; volumeScale: number }
     >((draft, { audioKey, volumeScale }) => {
       draft.audioItems[audioKey].query!.volumeScale = volumeScale;
+    }),
+    [SET_AUDIO_PRE_PHONEME_LENGTH]: createCommandAction<
+      State,
+      { audioKey: string; prePhonemeLength: number }
+    >((draft, { audioKey, prePhonemeLength }) => {
+      draft.audioItems[audioKey].query!.prePhonemeLength = prePhonemeLength;
+    }),
+    [SET_AUDIO_POST_PHONEME_LENGTH]: createCommandAction<
+      State,
+      { audioKey: string; postPhonemeLength: number }
+    >((draft, { audioKey, postPhonemeLength }) => {
+      draft.audioItems[audioKey].query!.postPhonemeLength = postPhonemeLength;
     }),
     [SET_AUDIO_ACCENT]: createCommandAction<
       State,


### PR DESCRIPTION
## 内容
音声の前後の無音部分の長さを制御するスライダーを追加
とりあえず0〜2秒（0.05秒刻み）にしています

PRするときにプロジェクトファイル関係を確認していないことに気づいたのでDraftにしています
<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #106 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
![vv](https://user-images.githubusercontent.com/44311840/133219644-f8d2502f-46eb-4875-b7ae-f47033398afb.png)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
自環境では再生時・保存されたファイルで変更が反映されているのを確認
ほとんど初めて触る言語なので自信がない