### PR TITLE
コマンド実装方式の追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18351,9 +18351,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
-      "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@openapitools/openapi-generator-cli": "^2.3.3",
     "@types/chai": "^4.2.11",
     "@types/electron-devtools-installer": "^2.2.0",
-    "@types/markdown-it": "^12.2.0",
     "@types/encoding-japanese": "^1.0.18",
+    "@types/markdown-it": "^12.2.0",
     "@types/mocha": "^5.2.4",
     "@types/mousetrap": "^1.6.8",
     "@types/uuid": "^8.3.0",
@@ -78,7 +78,7 @@
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
     "spectron": "14.0.0",
-    "typescript": "~4.1.5",
+    "typescript": "^4.2.4",
     "vue-cli-plugin-electron-builder": "~2.0.0"
   }
 }

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -81,7 +81,7 @@ import {
   REGISTER_AUDIO_ITEM,
   PLAY_AUDIO,
   STOP_AUDIO,
-  REMOVE_AUDIO_ITEM,
+  COMMAND_REMOVE_AUDIO_ITEM,
   IS_ACTIVE,
   PUT_TEXTS,
   OPEN_TEXT_EDIT_CONTEXT_MENU,
@@ -223,7 +223,7 @@ export default defineComponent({
           emit("focusCell", { audioKey: audioKeys.value[index + 1] });
         }
 
-        store.dispatch(REMOVE_AUDIO_ITEM, { audioKey: props.audioKey });
+        store.dispatch(COMMAND_REMOVE_AUDIO_ITEM, { audioKey: props.audioKey });
       }
     };
 

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -21,8 +21,8 @@
       >
 
       <q-space />
-
-      <!-- <q-btn
+      <q-btn
+        v-if="isDevelopment"
         unelevated
         color="white"
         text-color="secondary"
@@ -30,8 +30,9 @@
         :disable="!canUndo || uiLocked"
         @click="undo"
         >元に戻す</q-btn
-    >
-    <q-btn
+      >
+      <q-btn
+        v-if="isDevelopment"
         unelevated
         color="white"
         text-color="secondary"
@@ -39,7 +40,7 @@
         :disable="!canRedo || uiLocked"
         @click="redo"
         >やり直す</q-btn
-    > -->
+      >
       <q-btn
         id="setting_button"
         unelevated
@@ -82,6 +83,8 @@ export default defineComponent({
     const store = useStore();
     const $q = useQuasar();
 
+    const isDevelopment = process.env.NODE_ENV === "development";
+
     const uiLocked = computed(() => store.getters[UI_LOCKED]);
     const canUndo = computed(() => store.getters[CAN_UNDO]);
     const canRedo = computed(() => store.getters[CAN_REDO]);
@@ -121,6 +124,7 @@ export default defineComponent({
     };
 
     return {
+      isDevelopment,
       uiLocked,
       canUndo,
       canRedo,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1,9 +1,15 @@
 import { AudioQuery, AccentPhrase, Configuration, DefaultApi } from "@/openapi";
-import { StoreOptions } from "vuex";
 import path from "path";
-import { createCommandAction } from "./command";
+import { oldCreateCommandAction } from "./command";
 import { v4 as uuidv4 } from "uuid";
-import { AudioItem, EngineState, SaveResultObject, State } from "./type";
+import {
+  AudioItem,
+  EngineState,
+  SaveResultObject,
+  State,
+  typeAsStoreOptions,
+  commandMutationsCreator,
+} from "./type";
 import { createUILockAction } from "./ui";
 import { CharacterInfo, Encoding as EncodingType } from "@/type/preload";
 import Encoding from "encoding-japanese";
@@ -74,7 +80,6 @@ export const SET_AUDIO_TEXT = "SET_AUDIO_TEXT";
 export const SET_AUDIO_CHARACTER_INDEX = "SET_AUDIO_CHARACTER_INDEX";
 export const CHANGE_CHARACTER_INDEX = "CHANGE_CHARACTER_INDEX";
 export const INSERT_AUDIO_ITEM = "INSERT_AUDIO_ITEM";
-export const REMOVE_AUDIO_ITEM = "REMOVE_AUDIO_ITEM";
 export const REMOVE_ALL_AUDIO_ITEM = "REMOVE_ALL_AUDIO_ITEM";
 export const REGISTER_AUDIO_ITEM = "REGISTER_AUDIO_ITEM";
 export const GET_AUDIO_CACHE = "GET_AUDIO_CACHE";
@@ -112,10 +117,13 @@ export const DETECTED_ENGINE_ERROR = "DETECTED_ENGINE_ERROR";
 export const RESTART_ENGINE = "RESTART_ENGINE";
 export const CHECK_FILE_EXISTS = "CHECK_FILE_EXISTS";
 
+// mutations
+const REMOVE_AUDIO_ITEM = "REMOVE_AUDIO_ITEM";
+
 const audioBlobCache: Record<string, Blob> = {};
 const audioElements: Record<string, HTMLAudioElement> = {};
 
-export const audioStore = {
+export const audioStore = typeAsStoreOptions({
   getters: {
     [ACTIVE_AUDIO_KEY](state) {
       return state._activeAudioKey !== undefined &&
@@ -162,6 +170,11 @@ export const audioStore = {
     ) {
       state.nowPlayingContinuously = nowPlaying;
     },
+    [REMOVE_AUDIO_ITEM]: (state, { audioKey }: { audioKey: string }) => {
+      state.audioKeys.splice(state.audioKeys.indexOf(audioKey), 1);
+      delete state.audioItems[audioKey];
+      delete state.audioStates[audioKey];
+    },
   },
 
   actions: {
@@ -205,12 +218,12 @@ export const audioStore = {
 
       commit(SET_CHARACTER_INFOS, { characterInfos });
     }),
-    [SET_AUDIO_TEXT]: createCommandAction(
+    [SET_AUDIO_TEXT]: oldCreateCommandAction(
       (draft, { audioKey, text }: { audioKey: string; text: string }) => {
         draft.audioItems[audioKey].text = text;
       }
     ),
-    [SET_AUDIO_CHARACTER_INDEX]: createCommandAction<
+    [SET_AUDIO_CHARACTER_INDEX]: oldCreateCommandAction<
       State,
       { audioKey: string; characterIndex: number }
     >((draft, { audioKey, characterIndex }) => {
@@ -226,7 +239,7 @@ export const audioStore = {
         return dispatch(FETCH_MORA_DATA, { audioKey });
       }
     },
-    [INSERT_AUDIO_ITEM]: createCommandAction(
+    [INSERT_AUDIO_ITEM]: oldCreateCommandAction(
       (
         draft,
         {
@@ -243,14 +256,7 @@ export const audioStore = {
         };
       }
     ),
-    [REMOVE_AUDIO_ITEM]: createCommandAction(
-      (draft, { audioKey }: { audioKey: string }) => {
-        draft.audioKeys.splice(draft.audioKeys.indexOf(audioKey), 1);
-        delete draft.audioItems[audioKey];
-        delete draft.audioStates[audioKey];
-      }
-    ),
-    [REMOVE_ALL_AUDIO_ITEM]: createCommandAction((draft) => {
+    [REMOVE_ALL_AUDIO_ITEM]: oldCreateCommandAction((draft) => {
       for (const audioKey of draft.audioKeys) {
         delete draft.audioItems[audioKey];
         delete draft.audioStates[audioKey];
@@ -286,7 +292,7 @@ export const audioStore = {
         return null;
       }
     },
-    [SET_ACCENT_PHRASES]: createCommandAction(
+    [SET_ACCENT_PHRASES]: oldCreateCommandAction(
       (
         draft,
         {
@@ -297,7 +303,7 @@ export const audioStore = {
         draft.audioItems[audioKey].query!.accentPhrases = accentPhrases;
       }
     ),
-    [SET_AUDIO_QUERY]: createCommandAction(
+    [SET_AUDIO_QUERY]: oldCreateCommandAction(
       (
         draft,
         { audioKey, audioQuery }: { audioKey: string; audioQuery: AudioQuery }
@@ -350,7 +356,7 @@ export const audioStore = {
           dispatch(SET_AUDIO_QUERY, { audioKey, audioQuery })
         );
     },
-    [SET_AUDIO_SPEED_SCALE]: createCommandAction(
+    [SET_AUDIO_SPEED_SCALE]: oldCreateCommandAction(
       (
         draft,
         { audioKey, speedScale }: { audioKey: string; speedScale: number }
@@ -358,37 +364,37 @@ export const audioStore = {
         draft.audioItems[audioKey].query!.speedScale = speedScale;
       }
     ),
-    [SET_AUDIO_PITCH_SCALE]: createCommandAction<
+    [SET_AUDIO_PITCH_SCALE]: oldCreateCommandAction<
       State,
       { audioKey: string; pitchScale: number }
     >((draft, { audioKey, pitchScale }) => {
       draft.audioItems[audioKey].query!.pitchScale = pitchScale;
     }),
-    [SET_AUDIO_INTONATION_SCALE]: createCommandAction<
+    [SET_AUDIO_INTONATION_SCALE]: oldCreateCommandAction<
       State,
       { audioKey: string; intonationScale: number }
     >((draft, { audioKey, intonationScale }) => {
       draft.audioItems[audioKey].query!.intonationScale = intonationScale;
     }),
-    [SET_AUDIO_VOLUME_SCALE]: createCommandAction<
+    [SET_AUDIO_VOLUME_SCALE]: oldCreateCommandAction<
       State,
       { audioKey: string; volumeScale: number }
     >((draft, { audioKey, volumeScale }) => {
       draft.audioItems[audioKey].query!.volumeScale = volumeScale;
     }),
-    [SET_AUDIO_PRE_PHONEME_LENGTH]: createCommandAction<
+    [SET_AUDIO_PRE_PHONEME_LENGTH]: oldCreateCommandAction<
       State,
       { audioKey: string; prePhonemeLength: number }
     >((draft, { audioKey, prePhonemeLength }) => {
       draft.audioItems[audioKey].query!.prePhonemeLength = prePhonemeLength;
     }),
-    [SET_AUDIO_POST_PHONEME_LENGTH]: createCommandAction<
+    [SET_AUDIO_POST_PHONEME_LENGTH]: oldCreateCommandAction<
       State,
       { audioKey: string; postPhonemeLength: number }
     >((draft, { audioKey, postPhonemeLength }) => {
       draft.audioItems[audioKey].query!.postPhonemeLength = postPhonemeLength;
     }),
-    [SET_AUDIO_ACCENT]: createCommandAction<
+    [SET_AUDIO_ACCENT]: oldCreateCommandAction<
       State,
       {
         audioKey: string;
@@ -415,7 +421,7 @@ export const audioStore = {
       await dispatch(SET_AUDIO_ACCENT, { audioKey, accentPhraseIndex, accent });
       return dispatch(FETCH_MORA_DATA, { audioKey });
     },
-    [TOGGLE_ACCENT_PHRASE_SPLIT]: createCommandAction<
+    [TOGGLE_ACCENT_PHRASE_SPLIT]: oldCreateCommandAction<
       State,
       {
         audioKey: string;
@@ -495,7 +501,7 @@ export const audioStore = {
       });
       return dispatch(FETCH_MORA_DATA, { audioKey });
     },
-    [SET_AUDIO_MORA_DATA]: createCommandAction<
+    [SET_AUDIO_MORA_DATA]: oldCreateCommandAction<
       State,
       {
         audioKey: string;
@@ -799,4 +805,22 @@ export const audioStore = {
       return window.electron.checkFileExists(file);
     },
   },
-} as StoreOptions<State>;
+} as const);
+
+export const COMMAND_REMOVE_AUDIO_ITEM = "COMMAND_REMOVE_AUDIO_ITEM";
+
+export const audioCommandStore = typeAsStoreOptions({
+  actions: {
+    [COMMAND_REMOVE_AUDIO_ITEM]: (
+      { commit },
+      payload: { audioKey: string }
+    ) => {
+      commit(COMMAND_REMOVE_AUDIO_ITEM, payload);
+    },
+  },
+  mutations: commandMutationsCreator({
+    [COMMAND_REMOVE_AUDIO_ITEM]: (draft, payload: { audioKey: string }) => {
+      audioStore.mutations[REMOVE_AUDIO_ITEM](draft, payload);
+    },
+  }),
+} as const);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -8,7 +8,7 @@ import {
 
 import { State } from "./type";
 import { commandStore } from "./command";
-import { audioStore } from "./audio";
+import { audioStore, audioCommandStore } from "./audio";
 import { projectStore } from "./project";
 import { uiStore } from "./ui";
 import { settingStore } from "./setting";
@@ -62,6 +62,7 @@ export const store = createStore<State>({
     ...commandStore.mutations,
     ...projectStore.mutations,
     ...settingStore.mutations,
+    ...audioCommandStore.mutations,
   },
 
   actions: {
@@ -70,6 +71,7 @@ export const store = createStore<State>({
     ...commandStore.actions,
     ...projectStore.actions,
     ...settingStore.actions,
+    ...audioCommandStore.actions,
     [GET_POLICY_TEXT]: async () => {
       return await window.electron.getPolicyText();
     },

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1,11 +1,12 @@
+import { StoreOptions, ActionTree, MutationTree } from "vuex";
 import { Operation } from "rfc6902";
 import { AudioQuery } from "@/openapi";
+import {
+  createCommandMutationTree,
+  PayloadRecipeTree,
+  PayloadMutationTree,
+} from "./command";
 import { CharacterInfo, SavingSetting } from "@/type/preload";
-
-export interface ICommand<S> {
-  undoOperations: Operation[];
-  redoOperations: Operation[];
-}
 
 export type State = {
   engineState: EngineState;
@@ -18,8 +19,8 @@ export type State = {
   audioDetailPaneOffset?: number;
   audioInfoPaneOffset?: number;
   nowPlayingContinuously: boolean;
-  undoCommands: ICommand<State>[];
-  redoCommands: ICommand<State>[];
+  undoCommands: Command[];
+  redoCommands: Command[];
   useGpu: boolean;
   isHelpDialogOpen: boolean;
   isSettingDialogOpen: boolean;
@@ -40,6 +41,11 @@ export type AudioState = {
   nowGenerating: boolean;
 };
 
+export type Command = {
+  undoOperations: Operation[];
+  redoOperations: Operation[];
+};
+
 export type EngineState = "STARTING" | "FAILED_STARTING" | "ERROR" | "READY";
 export type SaveResult =
   | "SUCCESS"
@@ -47,3 +53,17 @@ export type SaveResult =
   | "ENGINE_ERROR"
   | "CANCELED";
 export type SaveResultObject = { result: SaveResult; path: string | undefined };
+
+export const typeAsStoreOptions = <Arg extends StoreOptions<State>>(
+  arg: Arg
+): Arg => arg;
+export const typeAsMutationTree = <Arg extends MutationTree<State>>(
+  arg: Arg
+): Arg => arg;
+export const typeAsActionTree = <Arg extends ActionTree<State, State>>(
+  arg: Arg
+): Arg => arg;
+
+export const commandMutationsCreator = <Arg extends PayloadRecipeTree<State>>(
+  arg: Arg
+): PayloadMutationTree<State> => createCommandMutationTree<State, Arg>(arg);


### PR DESCRIPTION
## 内容
#138 のコマンドの主要処理部分のみを含むプルリクエストです。

Commandを一つのMutationとして実装することで、UNDO/REDOの順序を保証しています。非同期処理がコマンドに必要な場合、コマンドの発行前に(Action内で)非同期処理に必要な情報を事前に取得してから、Mutationに渡してください。

immerを用いたUNDO/RODOのOperationの記録の為にState全体のスナップショットを撮るためパフォーマンス上のボトルネックになる可能性が高いです。

例として`REMOVE_AUDIO_ITEM`を`COMMAND_REMOVE_AUDIO_ITEM`として変更しています。
以前の処理を完全に置き換えてはいないのでコメントで`@deprecated`を指定しています。

## 関連 Issue

ref #116

## スクリーンショット・動画など


## その他
