### PR TITLE
同期的コマンドの新方式への移行

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -78,7 +78,7 @@ import {
   SET_ACTIVE_AUDIO_KEY,
   SET_AUDIO_TEXT,
   CHANGE_CHARACTER_INDEX,
-  REGISTER_AUDIO_ITEM,
+  COMMAND_REGISTER_AUDIO_ITEM,
   PLAY_AUDIO,
   STOP_AUDIO,
   COMMAND_REMOVE_AUDIO_ITEM,
@@ -242,7 +242,7 @@ export default defineComponent({
       const characterIndex =
         store.state.audioItems[props.audioKey].characterIndex;
       const audioItem: AudioItem = { text: "", characterIndex: characterIndex };
-      await store.dispatch(REGISTER_AUDIO_ITEM, {
+      await store.dispatch(COMMAND_REGISTER_AUDIO_ITEM, {
         audioItem,
         prevAudioKey: props.audioKey,
       });

--- a/src/components/AudioInfo.vue
+++ b/src/components/AudioInfo.vue
@@ -131,12 +131,12 @@ import { computed, defineComponent } from "vue";
 import { useStore } from "@/store";
 import {
   ACTIVE_AUDIO_KEY,
-  SET_AUDIO_INTONATION_SCALE,
-  SET_AUDIO_PITCH_SCALE,
-  SET_AUDIO_SPEED_SCALE,
-  SET_AUDIO_VOLUME_SCALE,
-  SET_AUDIO_PRE_PHONEME_LENGTH,
-  SET_AUDIO_POST_PHONEME_LENGTH,
+  COMMAND_SET_AUDIO_INTONATION_SCALE,
+  COMMAND_SET_AUDIO_PITCH_SCALE,
+  COMMAND_SET_AUDIO_SPEED_SCALE,
+  COMMAND_SET_AUDIO_VOLUME_SCALE,
+  COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH,
+  COMMAND_SET_AUDIO_POST_PHONEME_LENGTH,
 } from "@/store/audio";
 import { UI_LOCKED } from "@/store/ui";
 import { AudioQuery } from "@/openapi";
@@ -201,7 +201,7 @@ export default defineComponent({
 
     const setAudioSpeedScale = (speedScale: number) => {
       previewAudioSpeedScale.stopPreview();
-      store.dispatch(SET_AUDIO_SPEED_SCALE, {
+      store.dispatch(COMMAND_SET_AUDIO_SPEED_SCALE, {
         audioKey: activeAudioKey.value!,
         speedScale,
       });
@@ -209,7 +209,7 @@ export default defineComponent({
 
     const setAudioPitchScale = (pitchScale: number) => {
       previewAudioPitchScale.stopPreview();
-      store.dispatch(SET_AUDIO_PITCH_SCALE, {
+      store.dispatch(COMMAND_SET_AUDIO_PITCH_SCALE, {
         audioKey: activeAudioKey.value!,
         pitchScale,
       });
@@ -217,7 +217,7 @@ export default defineComponent({
 
     const setAudioIntonationScale = (intonationScale: number) => {
       previewAudioIntonationScale.stopPreview();
-      store.dispatch(SET_AUDIO_INTONATION_SCALE, {
+      store.dispatch(COMMAND_SET_AUDIO_INTONATION_SCALE, {
         audioKey: activeAudioKey.value!,
         intonationScale,
       });
@@ -225,7 +225,7 @@ export default defineComponent({
 
     const setAudioVolumeScale = (volumeScale: number) => {
       previewAudioVolumeScale.stopPreview();
-      store.dispatch(SET_AUDIO_VOLUME_SCALE, {
+      store.dispatch(COMMAND_SET_AUDIO_VOLUME_SCALE, {
         audioKey: activeAudioKey.value!,
         volumeScale,
       });
@@ -233,7 +233,7 @@ export default defineComponent({
 
     const setAudioPrePhonemeLength = (prePhonemeLength: number) => {
       previewAudioPrePhonemeLength.stopPreview();
-      store.dispatch(SET_AUDIO_PRE_PHONEME_LENGTH, {
+      store.dispatch(COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH, {
         audioKey: activeAudioKey.value!,
         prePhonemeLength,
       });
@@ -241,7 +241,7 @@ export default defineComponent({
 
     const setAudioPostPhonemeLength = (postPhonemeLength: number) => {
       previewAudioPostPhonemeLength.stopPreview();
-      store.dispatch(SET_AUDIO_POST_PHONEME_LENGTH, {
+      store.dispatch(COMMAND_SET_AUDIO_POST_PHONEME_LENGTH, {
         audioKey: activeAudioKey.value!,
         postPhonemeLength,
       });

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -79,9 +79,7 @@ export const LOAD_CHARACTER = "LOAD_CHARACTER";
 export const SET_AUDIO_TEXT = "SET_AUDIO_TEXT";
 export const SET_AUDIO_CHARACTER_INDEX = "SET_AUDIO_CHARACTER_INDEX";
 export const CHANGE_CHARACTER_INDEX = "CHANGE_CHARACTER_INDEX";
-export const INSERT_AUDIO_ITEM = "INSERT_AUDIO_ITEM";
 export const REMOVE_ALL_AUDIO_ITEM = "REMOVE_ALL_AUDIO_ITEM";
-export const REGISTER_AUDIO_ITEM = "REGISTER_AUDIO_ITEM";
 export const GET_AUDIO_CACHE = "GET_AUDIO_CACHE";
 export const SET_ACCENT_PHRASES = "SET_ACCENT_PHRASES";
 export const FETCH_ACCENT_PHRASES = "FETCH_ACCENT_PHRASES";
@@ -89,12 +87,6 @@ export const FETCH_MORA_DATA = "FETCH_MORA_DATA";
 export const HAVE_AUDIO_QUERY = "HAVE_AUDIO_QUERY";
 export const SET_AUDIO_QUERY = "SET_AUDIO_QUERY";
 export const FETCH_AUDIO_QUERY = "FETCH_AUDIO_QUERY";
-export const SET_AUDIO_SPEED_SCALE = "SET_AUDIO_SPEED_SCALE";
-export const SET_AUDIO_PITCH_SCALE = "SET_AUDIO_PITCH_SCALE";
-export const SET_AUDIO_PRE_PHONEME_LENGTH = "SET_AUDIO_PRE_PHONEME_LENGTH";
-export const SET_AUDIO_POST_PHONEME_LENGTH = "SET_AUDIO_POST_PHONEME_LENGTH";
-export const SET_AUDIO_INTONATION_SCALE = "SET_AUDIO_INTONATION_SCALE";
-export const SET_AUDIO_VOLUME_SCALE = "SET_AUDIO_VOLUME_SCALE";
 export const SET_AUDIO_ACCENT = "SET_AUDIO_ACCENT";
 export const CHANGE_ACCENT = "CHANGE_ACCENT";
 export const TOGGLE_ACCENT_PHRASE_SPLIT = "TOGGLE_ACCENT_PHRASE_SPLIT";
@@ -118,7 +110,17 @@ export const RESTART_ENGINE = "RESTART_ENGINE";
 export const CHECK_FILE_EXISTS = "CHECK_FILE_EXISTS";
 
 // mutations
+const INSERT_AUDIO_ITEM = "INSERT_AUDIO_ITEM";
 const REMOVE_AUDIO_ITEM = "REMOVE_AUDIO_ITEM";
+const SET_AUDIO_SPEED_SCALE = "SET_AUDIO_SPEED_SCALE";
+const SET_AUDIO_PITCH_SCALE = "SET_AUDIO_PITCH_SCALE";
+const SET_AUDIO_INTONATION_SCALE = "SET_AUDIO_INTONATION_SCALE";
+const SET_AUDIO_VOLUME_SCALE = "SET_AUDIO_VOLUME_SCALE";
+const SET_AUDIO_PRE_PHONEME_LENGTH = "SET_AUDIO_PRE_PHONEME_LENGTH";
+const SET_AUDIO_POST_PHONEME_LENGTH = "SET_AUDIO_POST_PHONEME_LENGTH";
+
+// actions
+export const REGISTER_AUDIO_ITEM = "REGISTER_AUDIO_ITEM";
 
 const audioBlobCache: Record<string, Blob> = {};
 const audioElements: Record<string, HTMLAudioElement> = {};
@@ -170,10 +172,78 @@ export const audioStore = typeAsStoreOptions({
     ) {
       state.nowPlayingContinuously = nowPlaying;
     },
+    [INSERT_AUDIO_ITEM]: (
+      state,
+      {
+        audioItem,
+        audioKey,
+        prevAudioKey,
+      }: {
+        audioItem: AudioItem;
+        audioKey: string;
+        prevAudioKey: string | undefined;
+      }
+    ) => {
+      const index =
+        prevAudioKey !== undefined
+          ? state.audioKeys.indexOf(prevAudioKey) + 1
+          : state.audioKeys.length;
+      state.audioKeys.splice(index, 0, audioKey);
+      state.audioItems[audioKey] = audioItem;
+      state.audioStates[audioKey] = {
+        nowPlaying: false,
+        nowGenerating: false,
+      };
+    },
     [REMOVE_AUDIO_ITEM]: (state, { audioKey }: { audioKey: string }) => {
       state.audioKeys.splice(state.audioKeys.indexOf(audioKey), 1);
       delete state.audioItems[audioKey];
       delete state.audioStates[audioKey];
+    },
+    [SET_AUDIO_SPEED_SCALE]: (
+      state,
+      { audioKey, speedScale }: { audioKey: string; speedScale: number }
+    ) => {
+      state.audioItems[audioKey].query!.speedScale = speedScale;
+    },
+    [SET_AUDIO_PITCH_SCALE]: (
+      draft,
+      { audioKey, pitchScale }: { audioKey: string; pitchScale: number }
+    ) => {
+      draft.audioItems[audioKey].query!.pitchScale = pitchScale;
+    },
+    [SET_AUDIO_INTONATION_SCALE]: (
+      draft,
+      {
+        audioKey,
+        intonationScale,
+      }: { audioKey: string; intonationScale: number }
+    ) => {
+      draft.audioItems[audioKey].query!.intonationScale = intonationScale;
+    },
+    [SET_AUDIO_VOLUME_SCALE]: (
+      draft,
+      { audioKey, volumeScale }: { audioKey: string; volumeScale: number }
+    ) => {
+      draft.audioItems[audioKey].query!.volumeScale = volumeScale;
+    },
+    [SET_AUDIO_PRE_PHONEME_LENGTH]: (
+      draft,
+      {
+        audioKey,
+        prePhonemeLength,
+      }: { audioKey: string; prePhonemeLength: number }
+    ) => {
+      draft.audioItems[audioKey].query!.prePhonemeLength = prePhonemeLength;
+    },
+    [SET_AUDIO_POST_PHONEME_LENGTH]: (
+      draft,
+      {
+        audioKey,
+        postPhonemeLength,
+      }: { audioKey: string; postPhonemeLength: number }
+    ) => {
+      draft.audioItems[audioKey].query!.postPhonemeLength = postPhonemeLength;
     },
   },
 
@@ -239,23 +309,6 @@ export const audioStore = typeAsStoreOptions({
         return dispatch(FETCH_MORA_DATA, { audioKey });
       }
     },
-    [INSERT_AUDIO_ITEM]: oldCreateCommandAction(
-      (
-        draft,
-        {
-          audioItem,
-          audioKey,
-          index,
-        }: { audioItem: AudioItem; audioKey: string; index: number }
-      ) => {
-        draft.audioKeys.splice(index, 0, audioKey);
-        draft.audioItems[audioKey] = audioItem;
-        draft.audioStates[audioKey] = {
-          nowPlaying: false,
-          nowGenerating: false,
-        };
-      }
-    ),
     [REMOVE_ALL_AUDIO_ITEM]: oldCreateCommandAction((draft) => {
       for (const audioKey of draft.audioKeys) {
         delete draft.audioItems[audioKey];
@@ -264,18 +317,14 @@ export const audioStore = typeAsStoreOptions({
       draft.audioKeys.splice(0, draft.audioKeys.length);
     }),
     [REGISTER_AUDIO_ITEM](
-      { state, dispatch },
+      { commit },
       {
         audioItem,
         prevAudioKey,
       }: { audioItem: AudioItem; prevAudioKey: string | undefined }
     ) {
       const audioKey = uuidv4();
-      const index =
-        prevAudioKey !== undefined
-          ? state.audioKeys.indexOf(prevAudioKey) + 1
-          : state.audioKeys.length;
-      dispatch(INSERT_AUDIO_ITEM, { audioItem, audioKey, index });
+      commit(INSERT_AUDIO_ITEM, { audioItem, audioKey, prevAudioKey });
       audioElements[audioKey] = new Audio();
       return audioKey;
     },
@@ -356,44 +405,6 @@ export const audioStore = typeAsStoreOptions({
           dispatch(SET_AUDIO_QUERY, { audioKey, audioQuery })
         );
     },
-    [SET_AUDIO_SPEED_SCALE]: oldCreateCommandAction(
-      (
-        draft,
-        { audioKey, speedScale }: { audioKey: string; speedScale: number }
-      ) => {
-        draft.audioItems[audioKey].query!.speedScale = speedScale;
-      }
-    ),
-    [SET_AUDIO_PITCH_SCALE]: oldCreateCommandAction<
-      State,
-      { audioKey: string; pitchScale: number }
-    >((draft, { audioKey, pitchScale }) => {
-      draft.audioItems[audioKey].query!.pitchScale = pitchScale;
-    }),
-    [SET_AUDIO_INTONATION_SCALE]: oldCreateCommandAction<
-      State,
-      { audioKey: string; intonationScale: number }
-    >((draft, { audioKey, intonationScale }) => {
-      draft.audioItems[audioKey].query!.intonationScale = intonationScale;
-    }),
-    [SET_AUDIO_VOLUME_SCALE]: oldCreateCommandAction<
-      State,
-      { audioKey: string; volumeScale: number }
-    >((draft, { audioKey, volumeScale }) => {
-      draft.audioItems[audioKey].query!.volumeScale = volumeScale;
-    }),
-    [SET_AUDIO_PRE_PHONEME_LENGTH]: oldCreateCommandAction<
-      State,
-      { audioKey: string; prePhonemeLength: number }
-    >((draft, { audioKey, prePhonemeLength }) => {
-      draft.audioItems[audioKey].query!.prePhonemeLength = prePhonemeLength;
-    }),
-    [SET_AUDIO_POST_PHONEME_LENGTH]: oldCreateCommandAction<
-      State,
-      { audioKey: string; postPhonemeLength: number }
-    >((draft, { audioKey, postPhonemeLength }) => {
-      draft.audioItems[audioKey].query!.postPhonemeLength = postPhonemeLength;
-    }),
     [SET_AUDIO_ACCENT]: oldCreateCommandAction<
       State,
       {
@@ -807,20 +818,132 @@ export const audioStore = typeAsStoreOptions({
   },
 } as const);
 
+// commands
+export const COMMAND_REGISTER_AUDIO_ITEM = "COMMAND_REGISTER_AUDIO_ITEM";
 export const COMMAND_REMOVE_AUDIO_ITEM = "COMMAND_REMOVE_AUDIO_ITEM";
+export const COMMAND_SET_AUDIO_SPEED_SCALE = "COMMAND_SET_AUDIO_SPEED_SCALE";
+export const COMMAND_SET_AUDIO_PITCH_SCALE = "COMMAND_SET_AUDIO_PITCH_SCALE";
+export const COMMAND_SET_AUDIO_INTONATION_SCALE =
+  "COMMAND_SET_AUDIO_INTONATION_SCALE";
+export const COMMAND_SET_AUDIO_VOLUME_SCALE = "COMMAND_SET_AUDIO_VOLUME_SCALE";
+export const COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH =
+  "COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH";
+export const COMMAND_SET_AUDIO_POST_PHONEME_LENGTH =
+  "COMMAND_SET_AUDIO_POST_PHONEME_LENGTH";
 
 export const audioCommandStore = typeAsStoreOptions({
   actions: {
+    [COMMAND_REGISTER_AUDIO_ITEM]: (
+      { commit },
+      {
+        audioItem,
+        prevAudioKey,
+      }: {
+        audioItem: AudioItem;
+        prevAudioKey: string | undefined;
+      }
+    ) => {
+      const audioKey = uuidv4();
+      commit(COMMAND_REGISTER_AUDIO_ITEM, {
+        audioItem,
+        audioKey,
+        prevAudioKey,
+      });
+      audioElements[audioKey] = new Audio();
+      return audioKey;
+    },
     [COMMAND_REMOVE_AUDIO_ITEM]: (
       { commit },
       payload: { audioKey: string }
     ) => {
       commit(COMMAND_REMOVE_AUDIO_ITEM, payload);
     },
+    [COMMAND_SET_AUDIO_SPEED_SCALE]: (
+      { commit },
+      payload: { audioKey: string; speedScale: number }
+    ) => {
+      commit(COMMAND_SET_AUDIO_SPEED_SCALE, payload);
+    },
+    [COMMAND_SET_AUDIO_PITCH_SCALE]: (
+      { commit },
+      payload: { audioKey: string; pitchScale: number }
+    ) => {
+      commit(COMMAND_SET_AUDIO_PITCH_SCALE, payload);
+    },
+    [COMMAND_SET_AUDIO_INTONATION_SCALE]: (
+      { commit },
+      payload: { audioKey: string; intonationScale: number }
+    ) => {
+      commit(COMMAND_SET_AUDIO_INTONATION_SCALE, payload);
+    },
+    [COMMAND_SET_AUDIO_VOLUME_SCALE]: (
+      { commit },
+      payload: { audioKey: string; volumeScale: number }
+    ) => {
+      commit(COMMAND_SET_AUDIO_VOLUME_SCALE, payload);
+    },
+    [COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH]: (
+      { commit },
+      payload: { audioKey: string; prePhonemeLength: number }
+    ) => {
+      commit(COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH, payload);
+    },
+    [COMMAND_SET_AUDIO_POST_PHONEME_LENGTH]: (
+      { commit },
+      payload: { audioKey: string; postPhonemeLength: number }
+    ) => {
+      commit(COMMAND_SET_AUDIO_POST_PHONEME_LENGTH, payload);
+    },
   },
   mutations: commandMutationsCreator({
+    [COMMAND_REGISTER_AUDIO_ITEM]: (
+      draft,
+      payload: {
+        audioItem: AudioItem;
+        audioKey: string;
+        prevAudioKey: string | undefined;
+      }
+    ) => {
+      audioStore.mutations[INSERT_AUDIO_ITEM](draft, payload);
+    },
     [COMMAND_REMOVE_AUDIO_ITEM]: (draft, payload: { audioKey: string }) => {
       audioStore.mutations[REMOVE_AUDIO_ITEM](draft, payload);
+    },
+    [COMMAND_SET_AUDIO_SPEED_SCALE]: (
+      draft,
+      payload: { audioKey: string; speedScale: number }
+    ) => {
+      audioStore.mutations[SET_AUDIO_SPEED_SCALE](draft, payload);
+    },
+    [COMMAND_SET_AUDIO_PITCH_SCALE]: (
+      draft,
+      payload: { audioKey: string; pitchScale: number }
+    ) => {
+      audioStore.mutations[SET_AUDIO_PITCH_SCALE](draft, payload);
+    },
+    [COMMAND_SET_AUDIO_INTONATION_SCALE]: (
+      draft,
+      payload: { audioKey: string; intonationScale: number }
+    ) => {
+      audioStore.mutations[SET_AUDIO_INTONATION_SCALE](draft, payload);
+    },
+    [COMMAND_SET_AUDIO_VOLUME_SCALE]: (
+      draft,
+      payload: { audioKey: string; volumeScale: number }
+    ) => {
+      audioStore.mutations[SET_AUDIO_VOLUME_SCALE](draft, payload);
+    },
+    [COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH]: (
+      draft,
+      payload: { audioKey: string; prePhonemeLength: number }
+    ) => {
+      audioStore.mutations[SET_AUDIO_PRE_PHONEME_LENGTH](draft, payload);
+    },
+    [COMMAND_SET_AUDIO_POST_PHONEME_LENGTH]: (
+      draft,
+      payload: { audioKey: string; postPhonemeLength: number }
+    ) => {
+      audioStore.mutations[SET_AUDIO_POST_PHONEME_LENGTH](draft, payload);
     },
   }),
 } as const);

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -129,6 +129,7 @@ import {
   IMPORT_FROM_FILE,
   LOAD_CHARACTER,
   REGISTER_AUDIO_ITEM,
+  COMMAND_REGISTER_AUDIO_ITEM,
 } from "@/store/audio";
 import {
   UI_LOCKED,
@@ -228,7 +229,7 @@ export default defineComponent({
       const characterIndex =
         store.state.audioItems[prevAudioKey].characterIndex;
       const audioItem: AudioItem = { text: "", characterIndex: characterIndex };
-      const newAudioKey = await store.dispatch(REGISTER_AUDIO_ITEM, {
+      const newAudioKey = await store.dispatch(COMMAND_REGISTER_AUDIO_ITEM, {
         audioItem,
         prevAudioKey: activeAudioKey.value,
       });


### PR DESCRIPTION
## 内容
#233 で追加したコマンドの実装方式を他のプルリクエストに影響の少なそうな非同期的なコマンドに限って移行しました。

移行したコマンドは
`REGISTER_AUDIO_ITEM`
`SET_AUDIO_SPEED_SCALE`
`SET_AUDIO_PITCH_SCALE`
`SET_AUDIO_INTONATION_SCALE`
`SET_AUDIO_VOLUME_SCALE`
`SET_AUDIO_PRE_PHONEME_LENGTH`
`SET_AUDIO_POST_PHONEME_LENGTH`
です。

ref #138
ref #233 

## 関連 Issue
ref #116

## 補足
`REGISTER_AUDIO_ITEM`は記録すべきでない（コマンドでない）操作も担っていたのでactionとしても残っています。
