### PR TITLE
[HOTFIX(for developer)]add publish option (fixed owner and repo, remove version's "v")

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -45,6 +45,12 @@ module.exports = {
           oneClick: false,
           allowToChangeInstallationDirectory: true,
         },
+        publish: {
+          provider: "github",
+          owner: "Hiroshiba",
+          repo: "voicevox",
+          vPrefixedTagName: false,
+        },
       },
     },
   },

--- a/vue.config.js
+++ b/vue.config.js
@@ -47,7 +47,6 @@ module.exports = {
         },
         publish: {
           provider: "github",
-          owner: "Hiroshiba",
           repo: "voicevox",
           vPrefixedTagName: false,
         },


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->

`vue.config.js`に`publish`を追加し、publish場所を固定(`installer.nsh`内の`APP_PACKAGE_URL`が、ビルドリポジトリに影響されることなく、固定される)。
さらに、`installer.nsh`内の`APP_PACKAGE_URL`に`version`値として`v`が入ることを抑止(`vPrefixedTagName`オプションを`false`に)

この設定により、どんな環境でビルドされても、nsis-webが見に行くダウンロード元が固定されます。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #210 
ref #244 