### PR TITLE
読み仮名の修正

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -423,11 +423,17 @@ export const audioStore = typeAsStoreOptions({
       }
     ) => {
       const audioItem = state.audioItems[audioKey];
+
+      // ひらがな(U+3041~U+3094)とカタカナ(U+30A1~U+30F4)のみで構成される場合、
+      // 「読み仮名」としてこれを処理する
       const kanaRegex = /^[\u3041-\u3094\u30A1-\u30F4]+$/;
       if (kanaRegex.test(newPronunciation)) {
+        // ひらがなが混ざっている場合はカタカナに変換
         const katakana = newPronunciation.replace(/[\u3041-\u3094]/g, (s) => {
           return String.fromCharCode(s.charCodeAt(0) + 0x60);
         });
+        // アクセントを末尾につけaccent phraseの生成をリクエスト
+        // 判別できない読み仮名が混じっていた場合400エラーが帰るのでfallback
         return api
           .accentPhrasesAccentPhrasesPost({
             text: katakana + "'",

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -423,6 +423,34 @@ export const audioStore = typeAsStoreOptions({
       }
     ) => {
       const audioItem = state.audioItems[audioKey];
+      const katakanaRegex = /^[\u30A0-\u30FF]+$/;
+      if (katakanaRegex.test(newPronunciation)) {
+        return api
+          .accentPhrasesAccentPhrasesPost({
+            text: newPronunciation + "'",
+            speaker:
+              state.characterInfos![audioItem.characterIndex!].metas.speaker,
+            isKana: true,
+          })
+          .catch(() => {
+            // fallback
+            return api.accentPhrasesAccentPhrasesPost({
+              text: newPronunciation,
+              speaker:
+                state.characterInfos![audioItem.characterIndex!].metas.speaker,
+              isKana: false,
+            });
+          })
+          .then((accentPhrases) => {
+            dispatch(SET_SINGLE_ACCENT_PHRASE, {
+              audioKey: audioKey,
+              accentPhraseIndex,
+              accentPhrases,
+              popUntilPause,
+            });
+          });
+      }
+
       return api
         .accentPhrasesAccentPhrasesPost({
           text: newPronunciation,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -423,11 +423,14 @@ export const audioStore = typeAsStoreOptions({
       }
     ) => {
       const audioItem = state.audioItems[audioKey];
-      const katakanaRegex = /^[\u30A0-\u30FF]+$/;
-      if (katakanaRegex.test(newPronunciation)) {
+      const kanaRegex = /^[\u3041-\u3094\u30A1-\u30F4]+$/;
+      if (kanaRegex.test(newPronunciation)) {
+        const katakana = newPronunciation.replace(/[\u3041-\u3094]/g, (s) => {
+          return String.fromCharCode(s.charCodeAt(0) + 0x60);
+        });
         return api
           .accentPhrasesAccentPhrasesPost({
-            text: newPronunciation + "'",
+            text: katakana + "'",
             speaker:
               state.characterInfos![audioItem.characterIndex!].metas.speaker,
             isKana: true,


### PR DESCRIPTION
## 内容
モーラのポップアップに入力した文字列がカタカナのみの場合、それを読み仮名として判断しaccent_phraseを生成する

アクセント位置は適当に設定される

失敗時は今までのis_kana=falseにフォールバック

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #157
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/8027142/134190561-d4da51a8-e96f-4649-920a-00ea37301e09.png)
↓
![image](https://user-images.githubusercontent.com/8027142/134190634-4aa5d209-a138-4f76-9edf-2596801de0a8.png)
↓
![image](https://user-images.githubusercontent.com/8027142/134190665-16ea5d92-f0c5-40c1-a732-10a9443539ca.png)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
