### PR TITLE
[HOTFIX] add kana as optionalProperties on audioQuerySchema

### DIFF
--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -292,6 +292,9 @@ const audioQuerySchema = {
     outputSamplingRate: { type: "int32" },
     outputStereo: { type: "boolean" },
   },
+  optionalProperties: {
+    kana: { type: "string" },
+  },
 } as const;
 
 const audioItemSchema = {


### PR DESCRIPTION
## 内容

`kana` プロパティがある vvproj ファイルの読み込みに失敗する
