### PR TITLE
Electronビルド時に同梱するVOICEVOX ENGINEのディレクトリを環境変数から変更できるようにする

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const process = require("process");
+
+const VOICEVOX_ENGINE_DIR =
+  process.env.VOICEVOX_ENGINE_DIR ?? "../voicevox_engine/run.dist/";
 
 module.exports = {
   configureWebpack: {
@@ -19,7 +24,7 @@ module.exports = {
         extraFiles: [
           { from: ".env.production", to: ".env" },
           {
-            from: "../voicevox_engine/run.dist/",
+            from: VOICEVOX_ENGINE_DIR,
             to: "",
           },
         ],


### PR DESCRIPTION
## 内容

Electronビルド時に、同梱するVOICEVOX ENGINEのビルド成果物のディレクトリを環境変数から変更できるようにします。

## 関連 Issue

ref #219 
ref #264 

## 議論

#264 の進め方によっては、VOICEVOX ENGINEのディレクトリを変更するのではなく、VOICEVOX ENGINEを同梱しないようにするオプションを追加するPRを作成するかもしれません。

例えば用途としては、CIの容量制限回避のため、ArtifactにElectronのビルド成果物のみを一度アップロードしてから、別JobでVOICEVOX ENGINEを結合するような形を考えていますが、NSIS側で結合後の7zのハッシュチェックをしていたらできなさそうです..。

GitHub Actionsの容量制限は14GBですが、
VOICEVOX ENGINEのWindows NVIDIA GPU用実行バイナリは、5.5GBあるため、現在の実装では、
コピー元のVOICEVOX ENGINE・Electronビルド成果物の分割前7z・分割後7zの3つ合わせて16.5GB必要になってしまいます。

一応、現在もVOICEVOX ENGINEが存在しなくてもビルドすることはできますが、ビルド時の警告を消すような形と思います。

また、この方法をとる場合、 `build/splitNsisArchive.js` の処理をスキップするオプションも追加して、これをCI側で再実装する必要がありそうです。

- `*.7z.ini`ファイル生成の実装例: https://gist.github.com/aoirint/71368263dd5118abab699ccaed67379c
