### PR TITLE
非同期コマンドの新方式への移行例

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -155,9 +155,9 @@ import { computed, defineComponent, ref } from "vue";
 import { useStore } from "@/store";
 import {
   ACTIVE_AUDIO_KEY,
-  CHANGE_ACCENT,
+  COMMAND_CHANGE_ACCENT,
   COMMAND_SET_AUDIO_MORA_DATA,
-  CHANGE_ACCENT_PHRASE_SPLIT,
+  COMMAND_CHANGE_ACCENT_PHRASE_SPLIT,
   PLAY_AUDIO,
   STOP_AUDIO,
   GENERATE_AND_SAVE_AUDIO,
@@ -216,7 +216,7 @@ export default defineComponent({
     const accentPhrases = computed(() => query.value?.accentPhrases);
 
     const changeAccent = (accentPhraseIndex: number, accent: number) => {
-      store.dispatch(CHANGE_ACCENT, {
+      store.dispatch(COMMAND_CHANGE_ACCENT, {
         audioKey: activeAudioKey.value!,
         accentPhraseIndex,
         accent,
@@ -228,7 +228,7 @@ export default defineComponent({
       isPause: boolean,
       moraIndex?: number
     ) => {
-      store.dispatch(CHANGE_ACCENT_PHRASE_SPLIT, {
+      store.dispatch(COMMAND_CHANGE_ACCENT_PHRASE_SPLIT, {
         audioKey: activeAudioKey.value!,
         accentPhraseIndex,
         moraIndex,


### PR DESCRIPTION
## 内容

非同期な旧コマンドを新コマンドに移行する例としてアクセントの操作に関連する以下のコマンドを移行しました。
| 移行前 | 移行後|
| --- | --- |
| `CHANGE_ACCENT` `SET_AUDIO_ACCENT` | `COMMAND_CHANGE_ACCENT`|
| `CHANGE_ACCENT_PHRASE_SPLIT` `TOGGLE_ACCENT_PHRASE_SPLIT` | `COMMAND_CHANGE_ACCENT_PHRASE_SPLIT` |

ref #258
ref #233

## 関連 Issue

ref #116

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
