### PR TITLE
Vuex Storeの型を厳密化するためのラッパーを追加する

### DIFF
--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -65,17 +65,29 @@ export function useStore<
 }
 
 export interface Dispatch<A extends ActionsBase> {
-  // TODO: payloadWithType方式の対応
   <T extends keyof A>(
     type: T,
     payload: Parameters<A[T]>[0],
     options?: DispatchOptions
   ): Promise<ReturnType<A[T]>>;
+  <T extends keyof A>(
+    payloadWithType: { type: T } & (Parameters<A[T]>[0] extends undefined
+      ? // eslint-disable-next-line @typescript-eslint/ban-types
+        {}
+      : Parameters<A[T]>[0]),
+    options?: DispatchOptions
+  ): Promise<ReturnType<A[T]>>;
 }
 
 export interface Commit<M extends MutationsBase> {
-  // TODO: payloadWithType方式の対応
   <T extends keyof M>(type: T, payload: M[T], options?: CommitOptions): void;
+  <T extends keyof M>(
+    payloadWithType: { type: T } & (M[T] extends undefined
+      ? // eslint-disable-next-line @typescript-eslint/ban-types
+        {}
+      : M[T]),
+    options?: CommitOptions
+  ): void;
 }
 
 export interface StoreOptions<

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -13,7 +13,7 @@ import {
   MutationTree as OriginalMutationTree,
 } from "vuex";
 
-export type PayloadFunction = (payload?: any) => any;
+export type PayloadFunction = (payload?: Record<string, any>) => any;
 
 export type GettersBase = Record<string, any>;
 export type ActionsBase = Record<string, PayloadFunction>;

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -13,11 +13,11 @@ import {
   MutationTree as OriginalMutationTree,
 } from "vuex";
 
-export type PayloadFunction = (payload?: Record<string, any>) => any;
+export type PayloadFunction = (payload?: any) => any;
 
 export type GettersBase = Record<string, any>;
 export type ActionsBase = Record<string, PayloadFunction>;
-export type MutationsBase = Record<string, Record<string, any> | undefined>;
+export type MutationsBase = Record<string, any>;
 
 export class Store<
   S,
@@ -71,10 +71,13 @@ export interface Dispatch<A extends ActionsBase> {
     options?: DispatchOptions
   ): Promise<ReturnType<A[T]>>;
   <T extends keyof A>(
-    payloadWithType: { type: T } & (Parameters<A[T]>[0] extends undefined
-      ? // eslint-disable-next-line @typescript-eslint/ban-types
-        {}
-      : Parameters<A[T]>[0]),
+    payloadWithType: { type: T } & (Parameters<A[T]>[0] extends Record<
+      string,
+      any
+    >
+      ? Parameters<A[T]>[0]
+      : // eslint-disable-next-line @typescript-eslint/ban-types
+        {}),
     options?: DispatchOptions
   ): Promise<ReturnType<A[T]>>;
 }
@@ -82,10 +85,10 @@ export interface Dispatch<A extends ActionsBase> {
 export interface Commit<M extends MutationsBase> {
   <T extends keyof M>(type: T, payload: M[T], options?: CommitOptions): void;
   <T extends keyof M>(
-    payloadWithType: { type: T } & (M[T] extends undefined
-      ? // eslint-disable-next-line @typescript-eslint/ban-types
-        {}
-      : M[T]),
+    payloadWithType: { type: T } & (M[T] extends Record<string, any>
+      ? M[T]
+      : // eslint-disable-next-line @typescript-eslint/ban-types
+        {}),
     options?: CommitOptions
   ): void;
 }

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -1,0 +1,142 @@
+import { InjectionKey } from "vue";
+import {
+  Store as BaseStore,
+  createStore as baseCreateStore,
+  useStore as baseUseStore,
+  DispatchOptions,
+  CommitOptions,
+  ModuleTree,
+  Plugin,
+  StoreOptions as OriginalStoreOptions,
+  GetterTree as OriginalGetterTree,
+  ActionTree as OriginalActionTree,
+  MutationTree as OriginalMutationTree,
+} from "vuex";
+
+export class Store<S, G, A, M> extends BaseStore<S> {
+  constructor(options: OriginalStoreOptions<S>) {
+    super(options);
+  }
+
+  readonly getters!: G;
+
+  // 既に型がつけられているものを上書きすることになるので、TS2564を吐く、それの回避
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  dispatch: Dispatch<A>;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  commit: Commit<M>;
+}
+
+export function createStore<S, G, A, M>(
+  options: StoreOptions<S, G, A, M>
+): Store<S, G, A, M> {
+  // optionsをOriginalStoreOptions<S>で型キャストしないとTS2589を吐く
+  return baseCreateStore<S>(options as OriginalStoreOptions<S>) as Store<
+    S,
+    G,
+    A,
+    M
+  >;
+}
+
+export function useStore<S, G, A, M>(
+  injectKey?: InjectionKey<Store<S, G, A, M>> | string
+): Store<S, G, A, M> {
+  return baseUseStore<S>(injectKey) as Store<S, G, A, M>;
+}
+
+export interface Dispatch<A = any> {
+  // TODO: payloadWithType方式の対応
+  <T extends keyof A>(
+    type: A extends Record<string, any> ? T : string,
+    payload: A extends Record<string, any> ? Parameters<A[T]>[0] : any,
+    options?: DispatchOptions
+  ): Promise<ReturnType<A extends Record<string, any> ? A[T] : any>>;
+}
+
+export interface Commit<M = any> {
+  // TODO: payloadWithType方式の対応
+  <T extends keyof M>(
+    type: M extends Record<string, any> ? T : string,
+    payload: M extends Record<string, any> ? Parameters<M[T]>[0] : any,
+    options?: CommitOptions
+  ): void;
+}
+
+export interface StoreOptions<S, G, A, M> {
+  state: S | (() => S);
+  getters?: GetterTree<S, S, G>;
+  actions?: ActionTree<S, S, A, M>;
+  mutations?: MutationTree<S, M>;
+  modules?: ModuleTree<S>;
+  plugins?: Plugin<S>[];
+  strict?: boolean;
+  devtools?: boolean;
+}
+
+export type PayloadFunction = (payload?: any) => any;
+
+export interface ActionContext<S, R, A, M> {
+  dispatch: Dispatch<A>;
+  commit: Commit<M>;
+  state: S;
+  getters: any;
+  rootState: R;
+  rootGetters: any;
+}
+
+export type ActionHandler<S, R, P extends PayloadFunction, A, M> = (
+  this: Store<S, any, A, M>,
+  injectee: ActionContext<S, R, A, M>,
+  payload: Parameters<P>[0]
+) => ReturnType<P>;
+export interface ActionObject<S, R, P extends PayloadFunction, A, M> {
+  root?: boolean;
+  handler: ActionHandler<S, R, P, A, M>;
+}
+
+export type Getter<S, R, P extends PayloadFunction> = (
+  state: S,
+  getters: Parameters<P>[0],
+  rootState: R,
+  rootGetters: any
+) => ReturnType<P>;
+export type Action<S, R, P extends PayloadFunction, A, M> =
+  | ActionHandler<S, R, P, A, M>
+  | ActionObject<S, R, P, A, M>;
+export type Mutation<S, P extends PayloadFunction> = (
+  state: S,
+  payload: Parameters<P>[0]
+) => ReturnType<P>;
+
+export type GetterTree<S, R, G> = G extends Record<string, PayloadFunction>
+  ? GetterTree<S, R, G>
+  : OriginalGetterTree<S, R>;
+
+export type CustomGetterTree<S, R, G extends Record<string, PayloadFunction>> =
+  {
+    [K in keyof G]: Getter<S, R, G[K]>;
+  };
+
+export type ActionTree<S, R, A, M> = A extends Record<string, PayloadFunction>
+  ? CustomActionTree<S, R, A, M>
+  : OriginalActionTree<S, R>;
+
+export type CustomActionTree<
+  S,
+  R,
+  A extends Record<string, PayloadFunction>,
+  M
+> = {
+  [K in keyof A]: Action<S, R, A[K], A, M>;
+};
+
+export type MutationTree<S, M> = M extends Record<string, PayloadFunction>
+  ? CustomMutationTree<S, M>
+  : OriginalMutationTree<S>;
+
+export type CustomMutationTree<S, M extends Record<string, PayloadFunction>> = {
+  [K in keyof M]: Mutation<S, M[K]>;
+};


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #197 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

以下のようにtype(or interface)でpayload部分と返り値(getterは返り値のみ、ミスってますがmutationは引数のみ)を定義してあげると

![image](https://user-images.githubusercontent.com/34832037/134798076-688d41ea-21e9-4ae2-96dd-434d1995a8ce.png)

自動的に型が反映されます
![image](https://user-images.githubusercontent.com/34832037/134797984-9071cea0-521f-4808-8bfe-d29eefd205a8.png)
![image](https://user-images.githubusercontent.com/34832037/134798103-4d60945a-5fa0-436f-b2ff-7b22136604bb.png)
(文字列を代入してもOK)
![image](https://user-images.githubusercontent.com/34832037/134798355-576e13e8-161c-4192-bbed-38ea50430d53.png)


これにより、typeの時点で定義していないものは型エラーを吐くようになります。

## その他
無理くりVuex Storeの型を拡張した形のものになります。
Genericsの引数が増え、コードとしてのきれいさが失われているような気もしますが、できる限りGenericsを渡す頻度を下げるように実装したつもりです。

また、GetterやAction、Mutationをそれぞれ文字列の定数として定義していたものが、この型定義強化で不要になると思われます(文字列を直接代入して、間違っていれば型エラーを吐いてくれるようになるので)。
かなり大きなPRになる予定ですが、分けると型エラーだらけになってしまうので、このPRにひとまとめにするしかないかなと考えています。
