### PR TITLE
`FETCH_AND_SET_SINGLE_ACCENT_PHRASE`の新方式への移行

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -161,7 +161,7 @@ import {
   PLAY_AUDIO,
   STOP_AUDIO,
   GENERATE_AND_SAVE_AUDIO,
-  FETCH_AND_SET_SINGLE_ACCENT_PHRASE,
+  COMMAND_CHANGE_SINGLE_ACCENT_PHRASE,
 } from "@/store/audio";
 import { UI_LOCKED } from "@/store/ui";
 import Mousetrap from "mousetrap";
@@ -347,7 +347,7 @@ export default defineComponent({
         newPronunciation += pronunciationByPhrase.value[phraseIndex + 1];
         popUntilPause = true;
       }
-      store.dispatch(FETCH_AND_SET_SINGLE_ACCENT_PHRASE, {
+      store.dispatch(COMMAND_CHANGE_SINGLE_ACCENT_PHRASE, {
         audioKey: activeAudioKey.value,
         newPronunciation,
         accentPhraseIndex: phraseIndex,

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -301,23 +301,6 @@ export const audioStore = typeAsStoreOptions({
       const query = state.audioItems[audioKey].query!;
       query.accentPhrases[accentPhraseIndex].moras[moraIndex].pitch = pitch;
     },
-    [SET_AUDIO_MORA_DATA]: (
-      state,
-      {
-        audioKey,
-        accentPhraseIndex,
-        moraIndex,
-        pitch,
-      }: {
-        audioKey: string;
-        accentPhraseIndex: number;
-        moraIndex: number;
-        pitch: number;
-      }
-    ) => {
-      const query = state.audioItems[audioKey].query!;
-      query.accentPhrases[accentPhraseIndex].moras[moraIndex].pitch = pitch;
-    },
   },
 
   actions: {

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -98,6 +98,11 @@ export type AudioMutations = {
   SET_AUDIO_QUERY: { audioKey: string; audioQuery: AudioQuery };
   SET_AUDIO_CHARACTER_INDEX: { audioKey: string; characterIndex: number };
   SET_ACCENT_PHRASES: { audioKey: string; accentPhrases: AccentPhrase[] };
+  SET_SINGLE_ACCENT_PHRASE: {
+    audioKey: string;
+    accentPhraseIndex: number;
+    accentPhrases: AccentPhrase[];
+  };
   SET_AUDIO_MORA_DATA: {
     audioKey: string;
     accentPhraseIndex: number;
@@ -121,12 +126,6 @@ export type AudioActions = {
     audioKey: string;
     accentPhrases: AccentPhrase[];
   }): void;
-  SET_SINGLE_ACCENT_PHRASE(payload: {
-    audioKey: string;
-    accentPhraseIndex: number;
-    accentPhrases: AccentPhrase[];
-    popUntilPause: boolean;
-  }): void;
   SET_AUDIO_QUERY(payload: { audioKey: string; audioQuery: AudioQuery }): void;
   FETCH_ACCENT_PHRASES(payload: {
     text: string;
@@ -134,12 +133,6 @@ export type AudioActions = {
     isKana: boolean | undefined;
   }): AccentPhrase[];
   FETCH_AND_SET_ACCENT_PHRASES(payload: { audioKey: string }): void;
-  FETCH_AND_SET_SINGLE_ACCENT_PHRASE(payload: {
-    audioKey: string;
-    newPronunciation: string;
-    accentPhraseIndex: number;
-    popUntilPause: boolean;
-  }): void;
   FETCH_MORA_DATA(payload: {
     accentPhrases: AccentPhrase[];
     characterIndex: number;
@@ -216,6 +209,12 @@ export type AudioCommandActions = {
         }
     )
   ): void;
+  COMMAND_CHANGE_ACCENT_PHRASE_SPLIT(payload: {
+    audioKey: string;
+    newPronunciation: string;
+    accentPhraseIndex: number;
+    popUntilPause: boolean;
+  }): void;
   COMMAND_SET_AUDIO_MORA_DATA(payload: {
     audioKey: string;
     accentPhraseIndex: number;
@@ -277,6 +276,11 @@ export type AudioCommandMutations = {
   };
   COMMAND_CHANGE_ACCENT_PHRASE_SPLIT: {
     audioKey: string;
+    accentPhrases: AccentPhrase[];
+  };
+  COMMAND_CHANGE_SINGLE_ACCENT_PHRASE: {
+    audioKey: string;
+    accentPhraseIndex: number;
     accentPhrases: AccentPhrase[];
   };
   COMMAND_SET_AUDIO_MORA_DATA: {


### PR DESCRIPTION
## 内容

`FETCH_AND_SET_SINGLE_ACCENT_PHRASE`をoldCommandを利用しない`COMMAND_CHANGE_SINGLE_ACCENT_PHRASE`に変更しました。

ref #258
ref #233

## 関連 Issue

ref #116

## スクリーンショット・動画など

## その他
