### PR TITLE
licenses.json: nameやversionが出力されない不具合を修正

### DIFF
--- a/build/generateLicenses.js
+++ b/build/generateLicenses.js
@@ -38,7 +38,7 @@ const licenseJson = execSync(
 const checkerLicenses = JSON.parse(licenseJson);
 
 const licenses = Object.entries(checkerLicenses).map(([packageName, license]) => ({
-  name: license.name,
+  name: license.name ?? packageName,
   version: license.version,
   license: license.licenses,
   text: license.licenseText,

--- a/build/generateLicenses.js
+++ b/build/generateLicenses.js
@@ -14,8 +14,9 @@ const argv = yargs(hideBin(process.argv))
 
 const { execSync } = require("child_process");
 const fs = require("fs");
+const tmp = require("tmp");
 
-const customFormat = JSON.stringify({
+const customFormat = {
   name: "",
   version: "",
   description: "",
@@ -24,12 +25,15 @@ const customFormat = JSON.stringify({
   licenseFile: "none",
   licenseText: "none",
   licenseModified: "no"
-});
+};
+
+const customFormatFile = tmp.fileSync();
+fs.writeFileSync(customFormatFile.name, JSON.stringify(customFormat));
 
 // https://github.com/davglass/license-checker
 // npm install -g license-checker
 const licenseJson = execSync(
-  `license-checker --production --excludePrivatePackages --json --customPath ${customFormat}`,
+  `license-checker --production --excludePrivatePackages --json --customPath ${customFormatFile.name}`,
   {
     encoding: "utf-8"
   }
@@ -38,7 +42,7 @@ const licenseJson = execSync(
 const checkerLicenses = JSON.parse(licenseJson);
 
 const licenses = Object.entries(checkerLicenses).map(([packageName, license]) => ({
-  name: license.name ?? packageName,
+  name: license.name,
   version: license.version,
   license: license.licenses,
   text: license.licenseText,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7457,6 +7457,15 @@
             "uuid": "^3.3.2"
           }
         },
+        "tmp": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+          "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^2.6.3"
+          }
+        },
         "tough-cookie": {
           "version": "2.4.3",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -18276,12 +18285,23 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
       "dev": true,
       "requires": {
-        "rimraf": "^2.6.3"
+        "rimraf": "^3.0.0"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "to-arraybuffer": {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
     "spectron": "14.0.0",
+    "tmp": "^0.2.1",
     "typescript": "^4.2.4",
     "vue-cli-plugin-electron-builder": "~2.0.0",
     "yargs": "^17.2.1"


### PR DESCRIPTION
## 内容
#275 で `license-checker` の出力フォーマットを決めるJSONのファイルパスである、`--customPath`オプションに誤ってJSONそのまま渡していたため、出力フォーマットが設定されずにデフォルトの出力となり、`licenses.json`の`name`や`version`がundefinedになる（JSONに出力されない）問題を修正します（確認不足でした）。

## 関連 Issue

ref #275 
