### PR TITLE
Vuex Storeの型を改善する

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -14,12 +14,11 @@ import {
   AudioCommandActions,
   AudioCommandGetters,
   AudioCommandMutations,
-  useAllStoreAction,
+  VoiceVoxStoreOptions,
 } from "./type";
 import { createUILockAction } from "./ui";
 import { CharacterInfo, Encoding as EncodingType } from "@/type/preload";
 import Encoding from "encoding-japanese";
-import { StoreOptions } from "@/store/vuex";
 
 const api = new DefaultApi(
   new Configuration({ basePath: process.env.VUE_APP_ENGINE_URL })
@@ -132,8 +131,7 @@ SET_ACCENT_PHRASES;
 const audioBlobCache: Record<string, Blob> = {};
 const audioElements: Record<string, HTMLAudioElement> = {};
 
-export const audioStore: StoreOptions<
-  State,
+export const audioStore: VoiceVoxStoreOptions<
   AudioGetters,
   AudioActions,
   AudioMutations
@@ -833,8 +831,7 @@ export const COMMAND_SET_AUDIO_PRE_PHONEME_LENGTH =
 export const COMMAND_SET_AUDIO_POST_PHONEME_LENGTH =
   "COMMAND_SET_AUDIO_POST_PHONEME_LENGTH";
 
-export const audioCommandStore: StoreOptions<
-  State,
+export const audioCommandStore: VoiceVoxStoreOptions<
   AudioCommandGetters,
   AudioCommandActions,
   AudioCommandMutations
@@ -866,282 +863,269 @@ export const audioCommandStore: StoreOptions<
     ) => {
       commit(COMMAND_REMOVE_AUDIO_ITEM, payload);
     },
-    [COMMAND_CHANGE_CHARACTER_INDEX]: useAllStoreAction(
-      async (
-        { state, dispatch, commit },
-        {
-          audioKey,
-          characterIndex,
-        }: { audioKey: string; characterIndex: number }
-      ) => {
-        const query = state.audioItems[audioKey].query;
-        try {
-          if (query !== undefined) {
-            const accentPhrases = query.accentPhrases;
-            const newAccentPhrases: AccentPhrase[] = await dispatch(
-              FETCH_MORA_DATA,
-              {
-                accentPhrases,
-                characterIndex,
-              }
-            );
-            commit(COMMAND_CHANGE_CHARACTER_INDEX, {
-              characterIndex: characterIndex,
-              audioKey: audioKey,
-              update: "AccentPhrases",
-              accentPhrases: newAccentPhrases,
-            });
-          } else {
-            const text = state.audioItems[audioKey].text;
-            const query: AudioQuery = await dispatch(FETCH_AUDIO_QUERY, {
-              text: text,
-              characterIndex: characterIndex,
-            });
-            commit(COMMAND_CHANGE_CHARACTER_INDEX, {
+    [COMMAND_CHANGE_CHARACTER_INDEX]: async (
+      { state, dispatch, commit },
+      { audioKey, characterIndex }: { audioKey: string; characterIndex: number }
+    ) => {
+      const query = state.audioItems[audioKey].query;
+      try {
+        if (query !== undefined) {
+          const accentPhrases = query.accentPhrases;
+          const newAccentPhrases: AccentPhrase[] = await dispatch(
+            FETCH_MORA_DATA,
+            {
+              accentPhrases,
               characterIndex,
-              audioKey,
-              update: "AudioQuery",
-              query,
-            });
-          }
-        } catch (error) {
+            }
+          );
+          commit(COMMAND_CHANGE_CHARACTER_INDEX, {
+            characterIndex: characterIndex,
+            audioKey: audioKey,
+            update: "AccentPhrases",
+            accentPhrases: newAccentPhrases,
+          });
+        } else {
+          const text = state.audioItems[audioKey].text;
+          const query: AudioQuery = await dispatch(FETCH_AUDIO_QUERY, {
+            text: text,
+            characterIndex: characterIndex,
+          });
           commit(COMMAND_CHANGE_CHARACTER_INDEX, {
             characterIndex,
             audioKey,
-            update: "CharacterIndex",
+            update: "AudioQuery",
+            query,
           });
-          throw error;
         }
-      }
-    ),
-    [COMMAND_CHANGE_ACCENT]: useAllStoreAction(
-      async (
-        { state, dispatch, commit },
-        {
+      } catch (error) {
+        commit(COMMAND_CHANGE_CHARACTER_INDEX, {
+          characterIndex,
           audioKey,
-          accentPhraseIndex,
-          accent,
-        }: {
-          audioKey: string;
-          accentPhraseIndex: number;
-          accent: number;
-        }
-      ) => {
-        const query = state.audioItems[audioKey].query;
-        if (query !== undefined) {
-          const newAccentPhrases: AccentPhrase[] = JSON.parse(
-            JSON.stringify(query.accentPhrases)
-          );
-          newAccentPhrases[accentPhraseIndex].accent = accent;
-
-          try {
-            const characterIndex: number =
-              state.audioItems[audioKey].characterIndex ?? 0;
-            const resultAccentPhrases: AccentPhrase[] = await dispatch(
-              FETCH_AND_COPY_MORA_DATA,
-              {
-                accentPhrases: newAccentPhrases,
-                characterIndex,
-                copyIndexes: [accentPhraseIndex],
-              }
-            );
-
-            commit(COMMAND_CHANGE_ACCENT, {
-              audioKey,
-              accentPhrases: resultAccentPhrases,
-            });
-          } catch (error) {
-            commit(COMMAND_CHANGE_ACCENT, {
-              audioKey,
-              accentPhrases: newAccentPhrases,
-            });
-            throw error;
-          }
-        }
+          update: "CharacterIndex",
+        });
+        throw error;
       }
-    ),
-    [COMMAND_CHANGE_ACCENT_PHRASE_SPLIT]: useAllStoreAction(
-      async (
-        { state, dispatch, commit },
-        payload: {
-          audioKey: string;
-          accentPhraseIndex: number;
-        } & (
-          | {
-              isPause: false;
-              moraIndex: number;
-            }
-          | {
-              isPause: true;
-            }
-        )
-      ) => {
-        const { audioKey, accentPhraseIndex } = payload;
-        const query: AudioQuery | undefined = state.audioItems[audioKey].query;
-        const characterIndex: number =
-          state.audioItems[audioKey].characterIndex ?? 0;
-        if (query === undefined) {
-          throw Error(
-            "`COMMAND_CHANGE_ACCENT_PHRASE_SPLIT` should not be called if the query does not exist."
-          );
-        }
+    },
+    [COMMAND_CHANGE_ACCENT]: async (
+      { state, dispatch, commit },
+      {
+        audioKey,
+        accentPhraseIndex,
+        accent,
+      }: {
+        audioKey: string;
+        accentPhraseIndex: number;
+        accent: number;
+      }
+    ) => {
+      const query = state.audioItems[audioKey].query;
+      if (query !== undefined) {
         const newAccentPhrases: AccentPhrase[] = JSON.parse(
           JSON.stringify(query.accentPhrases)
         );
-        const changeIndexes = [accentPhraseIndex];
-        // toggleAccentPhrase to newAccentPhrases and recored changeIndexes
-        {
-          const mergeAccent = (
-            accentPhrases: AccentPhrase[],
-            accentPhraseIndex: number
-          ) => {
-            const newAccentPhrase: AccentPhrase = {
-              moras: [
-                ...accentPhrases[accentPhraseIndex].moras,
-                ...accentPhrases[accentPhraseIndex + 1].moras,
-              ],
-              accent: accentPhrases[accentPhraseIndex].accent,
-              pauseMora: accentPhrases[accentPhraseIndex + 1].pauseMora,
-            };
-            accentPhrases.splice(accentPhraseIndex, 2, newAccentPhrase);
-          };
-          const splitAccent = (
-            accentPhrases: AccentPhrase[],
-            accentPhraseIndex: number,
-            moraIndex: number
-          ) => {
-            const newAccentPhrase1: AccentPhrase = {
-              moras: accentPhrases[accentPhraseIndex].moras.slice(
-                0,
-                moraIndex + 1
-              ),
-              accent:
-                accentPhrases[accentPhraseIndex].accent > moraIndex
-                  ? moraIndex + 1
-                  : accentPhrases[accentPhraseIndex].accent,
-              pauseMora: undefined,
-            };
-            const newAccentPhrase2: AccentPhrase = {
-              moras: accentPhrases[accentPhraseIndex].moras.slice(
-                moraIndex + 1
-              ),
-              accent:
-                accentPhrases[accentPhraseIndex].accent > moraIndex + 1
-                  ? accentPhrases[accentPhraseIndex].accent - moraIndex - 1
-                  : 1,
-              pauseMora: accentPhrases[accentPhraseIndex].pauseMora,
-            };
-            accentPhrases.splice(
-              accentPhraseIndex,
-              1,
-              newAccentPhrase1,
-              newAccentPhrase2
-            );
-          };
-
-          if (payload.isPause) {
-            mergeAccent(newAccentPhrases, accentPhraseIndex);
-          } else {
-            const moraIndex: number = payload.moraIndex;
-            if (
-              moraIndex ===
-              newAccentPhrases[accentPhraseIndex].moras.length - 1
-            ) {
-              mergeAccent(newAccentPhrases, accentPhraseIndex);
-            } else {
-              splitAccent(newAccentPhrases, accentPhraseIndex, moraIndex);
-              changeIndexes.push(accentPhraseIndex + 1);
-            }
-          }
-        }
+        newAccentPhrases[accentPhraseIndex].accent = accent;
 
         try {
+          const characterIndex: number =
+            state.audioItems[audioKey].characterIndex ?? 0;
           const resultAccentPhrases: AccentPhrase[] = await dispatch(
             FETCH_AND_COPY_MORA_DATA,
             {
               accentPhrases: newAccentPhrases,
               characterIndex,
-              copyIndexes: changeIndexes,
+              copyIndexes: [accentPhraseIndex],
             }
           );
-          commit(COMMAND_CHANGE_ACCENT_PHRASE_SPLIT, {
+
+          commit(COMMAND_CHANGE_ACCENT, {
             audioKey,
             accentPhrases: resultAccentPhrases,
           });
         } catch (error) {
-          commit(COMMAND_CHANGE_ACCENT_PHRASE_SPLIT, {
+          commit(COMMAND_CHANGE_ACCENT, {
             audioKey,
             accentPhrases: newAccentPhrases,
           });
           throw error;
         }
       }
-    ),
-    [COMMAND_CHANGE_SINGLE_ACCENT_PHRASE]: useAllStoreAction(
-      async (
-        { state, dispatch, commit },
-        {
-          audioKey,
-          newPronunciation,
-          accentPhraseIndex,
-          popUntilPause,
-        }: {
-          audioKey: string;
-          newPronunciation: string;
-          accentPhraseIndex: number;
-          popUntilPause: boolean;
-        }
-      ) => {
-        const characterIndex = state.audioItems[audioKey].characterIndex!;
-
-        let newAccentPhrasesSegment: AccentPhrase[] | undefined = undefined;
-
-        // ひらがな(U+3041~U+3094)とカタカナ(U+30A1~U+30F4)のみで構成される場合、
-        // 「読み仮名」としてこれを処理する
-        const kanaRegex = /^[\u3041-\u3094\u30A1-\u30F4]+$/;
-        if (kanaRegex.test(newPronunciation)) {
-          // ひらがなが混ざっている場合はカタカナに変換
-          const katakana = newPronunciation.replace(/[\u3041-\u3094]/g, (s) => {
-            return String.fromCharCode(s.charCodeAt(0) + 0x60);
-          });
-          // アクセントを末尾につけaccent phraseの生成をリクエスト
-          // 判別できない読み仮名が混じっていた場合400エラーが帰るのでfallback
-          newAccentPhrasesSegment = await dispatch(FETCH_ACCENT_PHRASES, {
-            text: katakana + "'",
-            characterIndex,
-            isKana: true,
-          }).catch(
-            // fallback
-            () =>
-              dispatch(FETCH_ACCENT_PHRASES, {
-                text: newPronunciation,
-                characterIndex,
-                isKana: false,
-              })
+    },
+    [COMMAND_CHANGE_ACCENT_PHRASE_SPLIT]: async (
+      { state, dispatch, commit },
+      payload: {
+        audioKey: string;
+        accentPhraseIndex: number;
+      } & (
+        | {
+            isPause: false;
+            moraIndex: number;
+          }
+        | {
+            isPause: true;
+          }
+      )
+    ) => {
+      const { audioKey, accentPhraseIndex } = payload;
+      const query: AudioQuery | undefined = state.audioItems[audioKey].query;
+      const characterIndex: number =
+        state.audioItems[audioKey].characterIndex ?? 0;
+      if (query === undefined) {
+        throw Error(
+          "`COMMAND_CHANGE_ACCENT_PHRASE_SPLIT` should not be called if the query does not exist."
+        );
+      }
+      const newAccentPhrases: AccentPhrase[] = JSON.parse(
+        JSON.stringify(query.accentPhrases)
+      );
+      const changeIndexes = [accentPhraseIndex];
+      // toggleAccentPhrase to newAccentPhrases and recored changeIndexes
+      {
+        const mergeAccent = (
+          accentPhrases: AccentPhrase[],
+          accentPhraseIndex: number
+        ) => {
+          const newAccentPhrase: AccentPhrase = {
+            moras: [
+              ...accentPhrases[accentPhraseIndex].moras,
+              ...accentPhrases[accentPhraseIndex + 1].moras,
+            ],
+            accent: accentPhrases[accentPhraseIndex].accent,
+            pauseMora: accentPhrases[accentPhraseIndex + 1].pauseMora,
+          };
+          accentPhrases.splice(accentPhraseIndex, 2, newAccentPhrase);
+        };
+        const splitAccent = (
+          accentPhrases: AccentPhrase[],
+          accentPhraseIndex: number,
+          moraIndex: number
+        ) => {
+          const newAccentPhrase1: AccentPhrase = {
+            moras: accentPhrases[accentPhraseIndex].moras.slice(
+              0,
+              moraIndex + 1
+            ),
+            accent:
+              accentPhrases[accentPhraseIndex].accent > moraIndex
+                ? moraIndex + 1
+                : accentPhrases[accentPhraseIndex].accent,
+            pauseMora: undefined,
+          };
+          const newAccentPhrase2: AccentPhrase = {
+            moras: accentPhrases[accentPhraseIndex].moras.slice(moraIndex + 1),
+            accent:
+              accentPhrases[accentPhraseIndex].accent > moraIndex + 1
+                ? accentPhrases[accentPhraseIndex].accent - moraIndex - 1
+                : 1,
+            pauseMora: accentPhrases[accentPhraseIndex].pauseMora,
+          };
+          accentPhrases.splice(
+            accentPhraseIndex,
+            1,
+            newAccentPhrase1,
+            newAccentPhrase2
           );
-        } else {
-          newAccentPhrasesSegment = await dispatch(FETCH_ACCENT_PHRASES, {
-            text: newPronunciation,
-            characterIndex: characterIndex,
-          });
-        }
+        };
 
-        if (popUntilPause) {
-          while (
-            newAccentPhrasesSegment[newAccentPhrasesSegment.length - 1]
-              .pauseMora === undefined
+        if (payload.isPause) {
+          mergeAccent(newAccentPhrases, accentPhraseIndex);
+        } else {
+          const moraIndex: number = payload.moraIndex;
+          if (
+            moraIndex ===
+            newAccentPhrases[accentPhraseIndex].moras.length - 1
           ) {
-            newAccentPhrasesSegment.pop();
+            mergeAccent(newAccentPhrases, accentPhraseIndex);
+          } else {
+            splitAccent(newAccentPhrases, accentPhraseIndex, moraIndex);
+            changeIndexes.push(accentPhraseIndex + 1);
           }
         }
+      }
 
-        commit(COMMAND_CHANGE_SINGLE_ACCENT_PHRASE, {
+      try {
+        const resultAccentPhrases: AccentPhrase[] = await dispatch(
+          FETCH_AND_COPY_MORA_DATA,
+          {
+            accentPhrases: newAccentPhrases,
+            characterIndex,
+            copyIndexes: changeIndexes,
+          }
+        );
+        commit(COMMAND_CHANGE_ACCENT_PHRASE_SPLIT, {
           audioKey,
-          accentPhraseIndex,
-          accentPhrases: newAccentPhrasesSegment,
+          accentPhrases: resultAccentPhrases,
+        });
+      } catch (error) {
+        commit(COMMAND_CHANGE_ACCENT_PHRASE_SPLIT, {
+          audioKey,
+          accentPhrases: newAccentPhrases,
+        });
+        throw error;
+      }
+    },
+    [COMMAND_CHANGE_SINGLE_ACCENT_PHRASE]: async (
+      { state, dispatch, commit },
+      {
+        audioKey,
+        newPronunciation,
+        accentPhraseIndex,
+        popUntilPause,
+      }: {
+        audioKey: string;
+        newPronunciation: string;
+        accentPhraseIndex: number;
+        popUntilPause: boolean;
+      }
+    ) => {
+      const characterIndex = state.audioItems[audioKey].characterIndex!;
+
+      let newAccentPhrasesSegment: AccentPhrase[] | undefined = undefined;
+
+      // ひらがな(U+3041~U+3094)とカタカナ(U+30A1~U+30F4)のみで構成される場合、
+      // 「読み仮名」としてこれを処理する
+      const kanaRegex = /^[\u3041-\u3094\u30A1-\u30F4]+$/;
+      if (kanaRegex.test(newPronunciation)) {
+        // ひらがなが混ざっている場合はカタカナに変換
+        const katakana = newPronunciation.replace(/[\u3041-\u3094]/g, (s) => {
+          return String.fromCharCode(s.charCodeAt(0) + 0x60);
+        });
+        // アクセントを末尾につけaccent phraseの生成をリクエスト
+        // 判別できない読み仮名が混じっていた場合400エラーが帰るのでfallback
+        newAccentPhrasesSegment = await dispatch(FETCH_ACCENT_PHRASES, {
+          text: katakana + "'",
+          characterIndex,
+          isKana: true,
+        }).catch(
+          // fallback
+          () =>
+            dispatch(FETCH_ACCENT_PHRASES, {
+              text: newPronunciation,
+              characterIndex,
+              isKana: false,
+            })
+        );
+      } else {
+        newAccentPhrasesSegment = await dispatch(FETCH_ACCENT_PHRASES, {
+          text: newPronunciation,
+          characterIndex: characterIndex,
         });
       }
-    ),
+
+      if (popUntilPause) {
+        while (
+          newAccentPhrasesSegment[newAccentPhrasesSegment.length - 1]
+            .pauseMora === undefined
+        ) {
+          newAccentPhrasesSegment.pop();
+        }
+      }
+
+      commit(COMMAND_CHANGE_SINGLE_ACCENT_PHRASE, {
+        audioKey,
+        accentPhraseIndex,
+        accentPhrases: newAccentPhrasesSegment,
+      });
+    },
     [COMMAND_SET_AUDIO_MORA_DATA]: (
       { commit },
       payload: {

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -9,6 +9,7 @@ import {
   CommandGetters,
   CommandActions,
   CommandMutations,
+  AllMutations,
 } from "./type";
 import { Mutation, MutationsBase, MutationTree } from "@/store/vuex";
 
@@ -137,10 +138,10 @@ export const createCommandMutationTree = <
  * @returns レシピと同じPayloadの型を持つMutation.
  */
 export const createCommandMutation =
-  <S extends UndoRedoState, M extends MutationsBase, K extends keyof M>(
-    payloadRecipe: PayloadRecipe<S, M[K]>
-  ): Mutation<S, M[K]> =>
-  (state: S, payload: M[K]): void => {
+  <S extends UndoRedoState, P extends AllMutations[keyof AllMutations]>(
+    payloadRecipe: PayloadRecipe<S, P>
+  ): Mutation<S, P> =>
+  (state: S, payload: P): void => {
     const command = recordOperations(payloadRecipe)(state, payload);
     applyPatch(state, command.redoOperations);
     state.undoCommands.push(command);
@@ -159,10 +160,10 @@ const patchToOperation = (patch: Patch): Operation => ({
  * @returns Function - レシピの操作を与えられたstateとpayloadを用いて記録したコマンドを返す関数。
  */
 const recordOperations =
-  <S extends UndoRedoState, M extends MutationsBase, K extends keyof M>(
-    recipe: PayloadRecipe<S, M[K]>
+  <S, P extends AllMutations[keyof AllMutations]>(
+    recipe: PayloadRecipe<S, P>
   ) =>
-  (state: S, payload: M[K]): Command => {
+  (state: S, payload: P): Command => {
     const [_, doPatches, undoPatches] = immer.produceWithPatches(
       // Taking snapshots has negative effects on performance.
       // This approach may cause a bottleneck.

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -1,5 +1,4 @@
 import { Action } from "vuex";
-import { StoreOptions } from "./vuex";
 
 import { enablePatches, enableMapSet, Patch, Draft, Immer } from "immer";
 import { applyPatch, Operation } from "rfc6902";
@@ -10,6 +9,7 @@ import {
   CommandActions,
   CommandMutations,
   AllMutations,
+  VoiceVoxStoreOptions,
 } from "./type";
 import { Mutation, MutationsBase, MutationTree } from "@/store/vuex";
 
@@ -176,8 +176,7 @@ const recordOperations =
     };
   };
 
-export const commandStore: StoreOptions<
-  State,
+export const commandStore: VoiceVoxStoreOptions<
   CommandGetters,
   CommandActions,
   CommandMutations

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,22 +1,16 @@
 import { InjectionKey } from "vue";
 import { createLogger } from "vuex";
-import {
-  createStore,
-  Store,
-  StoreOptions,
-  useStore as baseUseStore,
-} from "./vuex";
+import { createStore, Store, useStore as baseUseStore } from "./vuex";
 
 import {
-  actionsMixer,
   AllActions,
   AllGetters,
   AllMutations,
-  gettersMixer,
   IndexActions,
   IndexGetters,
   IndexMutations,
   State,
+  VoiceVoxStoreOptions,
 } from "./type";
 import { commandStore } from "./command";
 import { audioStore, audioCommandStore } from "./audio";
@@ -36,8 +30,7 @@ export const storeKey: InjectionKey<
   Store<State, AllGetters, AllActions, AllMutations>
 > = Symbol();
 
-export const indexStore: StoreOptions<
-  State,
+export const indexStore: VoiceVoxStoreOptions<
   IndexGetters,
   IndexActions,
   IndexMutations
@@ -91,7 +84,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     isPinned: false,
   },
 
-  getters: gettersMixer({
+  getters: {
     ...uiStore.getters,
     ...audioStore.getters,
     ...commandStore.getters,
@@ -99,7 +92,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...settingStore.getters,
     ...audioCommandStore.getters,
     ...indexStore.getters,
-  }),
+  },
 
   mutations: {
     ...uiStore.mutations,
@@ -111,7 +104,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...indexStore.mutations,
   },
 
-  actions: actionsMixer({
+  actions: {
     ...uiStore.actions,
     ...audioStore.actions,
     ...commandStore.actions,
@@ -119,7 +112,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     ...settingStore.actions,
     ...audioCommandStore.actions,
     ...indexStore.actions,
-  }),
+  },
   plugins: isDevelopment ? [createLogger()] : undefined,
   strict: process.env.NODE_ENV !== "production",
 });

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -1,4 +1,3 @@
-import { StoreOptions } from "./vuex";
 import { createUILockAction } from "@/store/ui";
 import {
   REGISTER_AUDIO_ITEM,
@@ -6,12 +5,11 @@ import {
   FETCH_MORA_DATA,
 } from "@/store/audio";
 import {
-  State,
   AudioItem,
   ProjectGetters,
   ProjectActions,
   ProjectMutations,
-  useAllStoreAction,
+  VoiceVoxStoreOptions,
 } from "@/store/type";
 
 import Ajv, { JTDDataType } from "ajv/dist/jtd";
@@ -25,8 +23,7 @@ export const SET_PROJECT_FILEPATH = "SET_PROJECT_FILEPATH";
 
 const DEFAULT_SAMPLING_RATE = 24000;
 
-export const projectStore: StoreOptions<
-  State,
+export const projectStore: VoiceVoxStoreOptions<
   ProjectGetters,
   ProjectActions,
   ProjectMutations
@@ -46,201 +43,194 @@ export const projectStore: StoreOptions<
   },
 
   actions: {
-    [CREATE_NEW_PROJECT]: useAllStoreAction(
-      createUILockAction(
-        async (context, { confirm }: { confirm?: boolean }) => {
+    [CREATE_NEW_PROJECT]: createUILockAction(
+      async (context, { confirm }: { confirm?: boolean }) => {
+        if (
+          confirm !== false &&
+          !(await window.electron.showConfirmDialog({
+            title: "警告",
+            message:
+              "保存されていないプロジェクトの変更は破棄されます。\n" +
+              "よろしいですか？",
+          }))
+        ) {
+          return;
+        }
+
+        await context.dispatch(REMOVE_ALL_AUDIO_ITEM, undefined);
+
+        const audioItem: AudioItem = { text: "", characterIndex: 0 };
+        await context.dispatch(REGISTER_AUDIO_ITEM, {
+          audioItem,
+        });
+
+        context.commit(SET_PROJECT_FILEPATH, { filePath: undefined });
+      }
+    ),
+    [LOAD_PROJECT_FILE]: createUILockAction(
+      async (
+        context,
+        { filePath, confirm }: { filePath?: string; confirm?: boolean }
+      ) => {
+        if (!filePath) {
+          // Select and load a project File.
+          const ret = await window.electron.showProjectLoadDialog({
+            title: "プロジェクトファイルの選択",
+          });
+          if (ret == undefined || ret?.length == 0) {
+            return;
+          }
+          filePath = ret[0];
+        }
+
+        const projectFileErrorMsg = `VOICEVOX Project file "${filePath}" is a invalid file.`;
+
+        try {
+          const buf = await window.electron.readFile({ filePath });
+          const text = new TextDecoder("utf-8").decode(buf).trim();
+          const obj = JSON.parse(text);
+
+          // appVersion Validation check
+          if (!("appVersion" in obj && typeof obj.appVersion === "string")) {
+            throw new Error(
+              projectFileErrorMsg +
+                " The appVersion of the project file should be string"
+            );
+          }
+          const appVersionList = versionTextParse(obj.appVersion);
+          const nowAppInfo = await window.electron.getAppInfos();
+          const nowAppVersionList = versionTextParse(nowAppInfo.version);
+          if (appVersionList == null || nowAppVersionList == null) {
+            throw new Error(
+              projectFileErrorMsg +
+                ' An invalid appVersion format. The appVersion should be in the format "%d.%d.%d'
+            );
+          }
+
+          // Migration
+          if (appVersionList < [0, 4, 0]) {
+            for (const audioItemsKey in obj.audioItems) {
+              if ("charactorIndex" in obj.audioItems[audioItemsKey]) {
+                obj.audioItems[audioItemsKey].characterIndex =
+                  obj.audioItems[audioItemsKey].charactorIndex;
+                delete obj.audioItems[audioItemsKey].charactorIndex;
+              }
+            }
+            for (const audioItemsKey in obj.audioItems) {
+              if (obj.audioItems[audioItemsKey].query != null) {
+                obj.audioItems[audioItemsKey].query.volumeScale = 1;
+                obj.audioItems[audioItemsKey].query.prePhonemeLength = 0.1;
+                obj.audioItems[audioItemsKey].query.postPhonemeLength = 0.1;
+                obj.audioItems[audioItemsKey].query.outputSamplingRate =
+                  DEFAULT_SAMPLING_RATE;
+              }
+            }
+          }
+
+          if (appVersionList < [0, 5, 0]) {
+            for (const audioItemsKey in obj.audioItems) {
+              const audioItem = obj.audioItems[audioItemsKey];
+              if (audioItem.query != null) {
+                audioItem.query.outputStereo = false;
+                for (const accentPhrase of audioItem.query.accentPhrases) {
+                  if (accentPhrase.pauseMora) {
+                    accentPhrase.pauseMora.vowelLength = 0;
+                  }
+                  for (const mora of accentPhrase.moras) {
+                    if (mora.consonant) {
+                      mora.consonantLength = 0;
+                    }
+                    mora.vowelLength = 0;
+                  }
+                }
+              }
+
+              // set phoneme length
+              await context
+                .dispatch(FETCH_MORA_DATA, {
+                  accentPhrases: audioItem.query!.accentPhrases,
+                  characterIndex: audioItem.characterIndex!,
+                })
+                .then((accentPhrases: AccentPhrase[]) => {
+                  accentPhrases.forEach((newAccentPhrase, i) => {
+                    const oldAccentPhrase = audioItem.query.accentPhrases[i];
+                    if (newAccentPhrase.pauseMora) {
+                      oldAccentPhrase.pauseMora.vowelLength =
+                        newAccentPhrase.pauseMora.vowelLength;
+                    }
+                    newAccentPhrase.moras.forEach((mora, j) => {
+                      if (mora.consonant) {
+                        oldAccentPhrase.moras[j].consonantLength =
+                          mora.consonantLength;
+                      }
+                      oldAccentPhrase.moras[j].vowelLength = mora.vowelLength;
+                    });
+                  });
+                });
+            }
+          }
+
+          // Validation check
+          const ajv = new Ajv();
+          const validate = ajv.compile(projectSchema);
+          if (!validate(obj)) {
+            throw validate.errors;
+          }
+          if (!obj.audioKeys.every((audioKey) => audioKey in obj.audioItems)) {
+            throw new Error(
+              projectFileErrorMsg +
+                " Every audioKey in audioKeys should be a key of audioItems"
+            );
+          }
+          if (
+            !obj.audioKeys.every(
+              (audioKey) => obj.audioItems[audioKey].characterIndex != undefined
+            )
+          ) {
+            throw new Error(
+              'Every audioItem should have a "characterIndex" attribute.'
+            );
+          }
+
           if (
             confirm !== false &&
             !(await window.electron.showConfirmDialog({
               title: "警告",
               message:
-                "保存されていないプロジェクトの変更は破棄されます。\n" +
+                "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
                 "よろしいですか？",
             }))
           ) {
             return;
           }
-
           await context.dispatch(REMOVE_ALL_AUDIO_ITEM, undefined);
 
-          const audioItem: AudioItem = { text: "", characterIndex: 0 };
-          await context.dispatch(REGISTER_AUDIO_ITEM, {
-            audioItem,
+          const { audioItems, audioKeys } = obj as ProjectType;
+
+          let prevAudioKey = undefined;
+          for (const audioKey of audioKeys) {
+            const audioItem = audioItems[audioKey];
+            prevAudioKey = await context.dispatch(REGISTER_AUDIO_ITEM, {
+              prevAudioKey,
+              audioItem,
+            });
+          }
+          context.commit(SET_PROJECT_FILEPATH, { filePath });
+        } catch (err) {
+          window.electron.logError(err);
+          const message = (() => {
+            if (typeof err === "string") return err;
+            if (!(err instanceof Error)) return "エラーが発生しました。";
+            if (err.message.startsWith(projectFileErrorMsg))
+              return "ファイルフォーマットが正しくありません。";
+            return err.message;
+          })();
+          await window.electron.showErrorDialog({
+            title: "エラー",
+            message,
           });
-
-          context.commit(SET_PROJECT_FILEPATH, { filePath: undefined });
         }
-      )
-    ),
-    [LOAD_PROJECT_FILE]: useAllStoreAction(
-      createUILockAction(
-        async (
-          context,
-          { filePath, confirm }: { filePath?: string; confirm?: boolean }
-        ) => {
-          if (!filePath) {
-            // Select and load a project File.
-            const ret = await window.electron.showProjectLoadDialog({
-              title: "プロジェクトファイルの選択",
-            });
-            if (ret == undefined || ret?.length == 0) {
-              return;
-            }
-            filePath = ret[0];
-          }
-
-          const projectFileErrorMsg = `VOICEVOX Project file "${filePath}" is a invalid file.`;
-
-          try {
-            const buf = await window.electron.readFile({ filePath });
-            const text = new TextDecoder("utf-8").decode(buf).trim();
-            const obj = JSON.parse(text);
-
-            // appVersion Validation check
-            if (!("appVersion" in obj && typeof obj.appVersion === "string")) {
-              throw new Error(
-                projectFileErrorMsg +
-                  " The appVersion of the project file should be string"
-              );
-            }
-            const appVersionList = versionTextParse(obj.appVersion);
-            const nowAppInfo = await window.electron.getAppInfos();
-            const nowAppVersionList = versionTextParse(nowAppInfo.version);
-            if (appVersionList == null || nowAppVersionList == null) {
-              throw new Error(
-                projectFileErrorMsg +
-                  ' An invalid appVersion format. The appVersion should be in the format "%d.%d.%d'
-              );
-            }
-
-            // Migration
-            if (appVersionList < [0, 4, 0]) {
-              for (const audioItemsKey in obj.audioItems) {
-                if ("charactorIndex" in obj.audioItems[audioItemsKey]) {
-                  obj.audioItems[audioItemsKey].characterIndex =
-                    obj.audioItems[audioItemsKey].charactorIndex;
-                  delete obj.audioItems[audioItemsKey].charactorIndex;
-                }
-              }
-              for (const audioItemsKey in obj.audioItems) {
-                if (obj.audioItems[audioItemsKey].query != null) {
-                  obj.audioItems[audioItemsKey].query.volumeScale = 1;
-                  obj.audioItems[audioItemsKey].query.prePhonemeLength = 0.1;
-                  obj.audioItems[audioItemsKey].query.postPhonemeLength = 0.1;
-                  obj.audioItems[audioItemsKey].query.outputSamplingRate =
-                    DEFAULT_SAMPLING_RATE;
-                }
-              }
-            }
-
-            if (appVersionList < [0, 5, 0]) {
-              for (const audioItemsKey in obj.audioItems) {
-                const audioItem = obj.audioItems[audioItemsKey];
-                if (audioItem.query != null) {
-                  audioItem.query.outputStereo = false;
-                  for (const accentPhrase of audioItem.query.accentPhrases) {
-                    if (accentPhrase.pauseMora) {
-                      accentPhrase.pauseMora.vowelLength = 0;
-                    }
-                    for (const mora of accentPhrase.moras) {
-                      if (mora.consonant) {
-                        mora.consonantLength = 0;
-                      }
-                      mora.vowelLength = 0;
-                    }
-                  }
-                }
-
-                // set phoneme length
-                await context
-                  .dispatch(FETCH_MORA_DATA, {
-                    accentPhrases: audioItem.query!.accentPhrases,
-                    characterIndex: audioItem.characterIndex!,
-                  })
-                  .then((accentPhrases: AccentPhrase[]) => {
-                    accentPhrases.forEach((newAccentPhrase, i) => {
-                      const oldAccentPhrase = audioItem.query.accentPhrases[i];
-                      if (newAccentPhrase.pauseMora) {
-                        oldAccentPhrase.pauseMora.vowelLength =
-                          newAccentPhrase.pauseMora.vowelLength;
-                      }
-                      newAccentPhrase.moras.forEach((mora, j) => {
-                        if (mora.consonant) {
-                          oldAccentPhrase.moras[j].consonantLength =
-                            mora.consonantLength;
-                        }
-                        oldAccentPhrase.moras[j].vowelLength = mora.vowelLength;
-                      });
-                    });
-                  });
-              }
-            }
-
-            // Validation check
-            const ajv = new Ajv();
-            const validate = ajv.compile(projectSchema);
-            if (!validate(obj)) {
-              throw validate.errors;
-            }
-            if (
-              !obj.audioKeys.every((audioKey) => audioKey in obj.audioItems)
-            ) {
-              throw new Error(
-                projectFileErrorMsg +
-                  " Every audioKey in audioKeys should be a key of audioItems"
-              );
-            }
-            if (
-              !obj.audioKeys.every(
-                (audioKey) =>
-                  obj.audioItems[audioKey].characterIndex != undefined
-              )
-            ) {
-              throw new Error(
-                'Every audioItem should have a "characterIndex" attribute.'
-              );
-            }
-
-            if (
-              confirm !== false &&
-              !(await window.electron.showConfirmDialog({
-                title: "警告",
-                message:
-                  "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
-                  "よろしいですか？",
-              }))
-            ) {
-              return;
-            }
-            await context.dispatch(REMOVE_ALL_AUDIO_ITEM, undefined);
-
-            const { audioItems, audioKeys } = obj as ProjectType;
-
-            let prevAudioKey = undefined;
-            for (const audioKey of audioKeys) {
-              const audioItem = audioItems[audioKey];
-              prevAudioKey = await context.dispatch(REGISTER_AUDIO_ITEM, {
-                prevAudioKey,
-                audioItem,
-              });
-            }
-            context.commit(SET_PROJECT_FILEPATH, { filePath });
-          } catch (err) {
-            window.electron.logError(err);
-            const message = (() => {
-              if (typeof err === "string") return err;
-              if (!(err instanceof Error)) return "エラーが発生しました。";
-              if (err.message.startsWith(projectFileErrorMsg))
-                return "ファイルフォーマットが正しくありません。";
-              return err.message;
-            })();
-            await window.electron.showErrorDialog({
-              title: "エラー",
-              message,
-            });
-          }
-        }
-      )
+      }
     ),
     [SAVE_PROJECT_FILE]: createUILockAction(
       async (context, { overwrite }: { overwrite?: boolean }) => {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -1,17 +1,15 @@
 import { SavingSetting } from "@/type/preload";
-import { StoreOptions } from "./vuex";
 import {
   SettingActions,
   SettingGetters,
   SettingMutations,
-  State,
+  VoiceVoxStoreOptions,
 } from "./type";
 
 export const GET_SAVING_SETTING_DATA = "GET_SAVING_SETTING_DATA";
 export const SET_SAVING_SETTING_DATA = "SET_SAVING_SETTING_DATA";
 
-export const settingStore: StoreOptions<
-  State,
+export const settingStore: VoiceVoxStoreOptions<
   SettingGetters,
   SettingActions,
   SettingMutations

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -1,10 +1,9 @@
 import {
   MutationTree,
   MutationsBase,
-  Action,
-  Getter,
-  ActionTree,
-  GetterTree,
+  GettersBase,
+  ActionsBase,
+  StoreOptions,
 } from "./vuex";
 import { Operation } from "rfc6902";
 import { AccentPhrase, AudioQuery } from "@/openapi";
@@ -475,28 +474,11 @@ export type UnionActions =
   | SettingActions
   | UiActions;
 
-export const useAllStoreGetter = <G extends UnionGetters, K extends keyof G>(
-  arg: (
-    state: State,
-    getters: AllGetters,
-    rootState: State,
-    rootGetters: any
-  ) => G[K]
-): Getter<State, State, G, K> => {
-  return (state, getters, rootState, rootGetters) =>
-    arg(state, getters as AllGetters, rootState, rootGetters);
-};
-
-export const useAllStoreAction = <K extends keyof AllActions>(
-  arg: Action<State, State, AllActions, AllMutations, K>
-): Action<State, State, AllActions, AllMutations, K> => arg;
-
-export const gettersMixer = (arg: GetterTree<State, State, UnionGetters>) =>
-  arg as GetterTree<State, State, AllGetters>;
-
-export const actionsMixer = (
-  arg: ActionTree<State, State, UnionActions, UnionMutations>
-) => arg as ActionTree<State, State, AllActions, AllMutations>;
+export type VoiceVoxStoreOptions<
+  G extends GettersBase,
+  A extends ActionsBase,
+  M extends MutationsBase
+> = StoreOptions<State, G, A, M, AllGetters, AllActions, AllMutations>;
 
 export const commandMutationsCreator = <M extends MutationsBase>(
   arg: PayloadRecipeTree<State, M>


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
#273 の中のレビューを元に、Vuex Storeの型を改善しました。

1. Vuex Storeの独立性を確保したまま型を拡張し、`useAllStore`系関数を撲滅しました。
2. 1に伴って、Vuex Storeに渡す`StoreOptions`をこのプロジェクト用にカスタムした、`VoiceVoxStoreOptions`を`store/type.ts`に配置、各ファイルでStoreOptions定義時にこれを使うようになりました。
3. `createCommandMutation`や`recordOperations`でMutationとそのキーを型として渡すのは健全ではないということで、Payloadを直接渡す形に戻しました。
4. 1のVuex Storeの型改善と、2で作られた`VoiceVoxStoreOptions`により、`gettersMixer`、`actionsMixer`が不要になったので排除しました。

eslintにより大幅にインデントが変更されているせいで、少し大きなPRに見えますが、そこまで大きな変更ではありません。
PRの粒度に迷いましたが、切り離せて`3`だけだったのでまとめてしまいました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
ref #273 

