### PR TITLE
AudioItemのcharaterIndexをspeakerに変更

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -11,8 +11,11 @@
             clickable
             v-close-popup
             active-class="selected-character-item"
-            :active="index === selectedCharacterInfo.metas.speaker"
-            @click="changeCharacterIndex(index)"
+            :active="
+              characterInfo.metas.speaker ===
+              selectedCharacterInfo.metas.speaker
+            "
+            @click="changeSpeaker(characterInfo.metas.speaker)"
           >
             <q-item-section avatar>
               <q-avatar rounded size="2rem">
@@ -77,7 +80,7 @@ import {
   HAVE_AUDIO_QUERY,
   SET_ACTIVE_AUDIO_KEY,
   SET_AUDIO_TEXT,
-  COMMAND_CHANGE_CHARACTER_INDEX,
+  COMMAND_CHANGE_SPEAKER,
   COMMAND_REGISTER_AUDIO_ITEM,
   PLAY_AUDIO,
   STOP_AUDIO,
@@ -117,9 +120,10 @@ export default defineComponent({
     );
 
     const selectedCharacterInfo = computed(() =>
-      characterInfos.value != undefined &&
-      audioItem.value.characterIndex != undefined
-        ? characterInfos.value[audioItem.value.characterIndex]
+      characterInfos.value != undefined && audioItem.value.speaker != undefined
+        ? characterInfos.value.find(
+            (info) => info.metas.speaker == audioItem.value.speaker
+          )
         : undefined
     );
 
@@ -140,10 +144,10 @@ export default defineComponent({
         });
       }
     };
-    const changeCharacterIndex = (characterIndex: number) => {
-      store.dispatch(COMMAND_CHANGE_CHARACTER_INDEX, {
+    const changeSpeaker = (speaker: number) => {
+      store.dispatch(COMMAND_CHANGE_SPEAKER, {
         audioKey: props.audioKey,
-        characterIndex,
+        speaker,
       });
     };
     const setActiveAudioKey = () => {
@@ -183,7 +187,7 @@ export default defineComponent({
 
           store.dispatch(PUT_TEXTS, {
             texts,
-            characterIndex: audioItem.value.characterIndex,
+            speaker: audioItem.value.speaker,
             prevAudioKey,
           });
         }
@@ -241,9 +245,8 @@ export default defineComponent({
 
     // 下にセルを追加
     const addCellBellow = async () => {
-      const characterIndex =
-        store.state.audioItems[props.audioKey].characterIndex;
-      const audioItem: AudioItem = { text: "", characterIndex: characterIndex };
+      const speaker = store.state.audioItems[props.audioKey].speaker;
+      const audioItem: AudioItem = { text: "", speaker: speaker };
       await store.dispatch(COMMAND_REGISTER_AUDIO_ITEM, {
         audioItem,
         prevAudioKey: props.audioKey,
@@ -294,7 +297,7 @@ export default defineComponent({
       characterIconUrl,
       setAudioText,
       updateAudioQuery,
-      changeCharacterIndex,
+      changeSpeaker,
       setActiveAudioKey,
       save,
       play,

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -26,10 +26,10 @@ export default defineComponent({
       const audioItem = activeAudioKey
         ? store.state.audioItems[activeAudioKey]
         : undefined;
-      const characterIndex = audioItem?.characterIndex;
+      const speaker = audioItem?.speaker;
 
-      return characterIndex !== undefined
-        ? characterInfos[characterIndex]
+      return speaker !== undefined
+        ? characterInfos.find((info) => info.metas.speaker == speaker)
         : undefined;
     });
 

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -59,7 +59,7 @@ export const projectStore: VoiceVoxStoreOptions<
 
         await context.dispatch(REMOVE_ALL_AUDIO_ITEM, undefined);
 
-        const audioItem: AudioItem = { text: "", characterIndex: 0 };
+        const audioItem: AudioItem = { text: "", speaker: 0 };
         await context.dispatch(REGISTER_AUDIO_ITEM, {
           audioItem,
         });
@@ -149,7 +149,7 @@ export const projectStore: VoiceVoxStoreOptions<
               await context
                 .dispatch(FETCH_MORA_DATA, {
                   accentPhrases: audioItem.query!.accentPhrases,
-                  characterIndex: audioItem.characterIndex!,
+                  speaker: audioItem.speaker!,
                 })
                 .then((accentPhrases: AccentPhrase[]) => {
                   accentPhrases.forEach((newAccentPhrase, i) => {
@@ -184,11 +184,11 @@ export const projectStore: VoiceVoxStoreOptions<
           }
           if (
             !obj.audioKeys.every(
-              (audioKey) => obj.audioItems[audioKey].characterIndex != undefined
+              (audioKey) => obj.audioItems[audioKey].speaker != undefined
             )
           ) {
             throw new Error(
-              'Every audioItem should have a "characterIndex" attribute.'
+              'Every audioItem should have a "speaker" attribute.'
             );
           }
 
@@ -314,7 +314,7 @@ const audioItemSchema = {
     text: { type: "string" },
   },
   optionalProperties: {
-    characterIndex: { type: "int32" },
+    speaker: { type: "int32" },
     query: audioQuerySchema,
   },
 } as const;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -43,7 +43,7 @@ export type State = {
 
 export type AudioItem = {
   text: string;
-  characterIndex?: number;
+  speaker?: number;
   query?: AudioQuery;
 };
 
@@ -101,7 +101,7 @@ export type AudioMutations = {
     postPhonemeLength: number;
   };
   SET_AUDIO_QUERY: { audioKey: string; audioQuery: AudioQuery };
-  SET_AUDIO_CHARACTER_INDEX: { audioKey: string; characterIndex: number };
+  SET_AUDIO_SPEAKER: { audioKey: string; speaker: number };
   SET_ACCENT_PHRASES: { audioKey: string; accentPhrases: AccentPhrase[] };
   SET_SINGLE_ACCENT_PHRASE: {
     audioKey: string;
@@ -134,22 +134,22 @@ export type AudioActions = {
   SET_AUDIO_QUERY(payload: { audioKey: string; audioQuery: AudioQuery }): void;
   FETCH_ACCENT_PHRASES(payload: {
     text: string;
-    characterIndex: number;
+    speaker: number;
     isKana?: boolean;
   }): Promise<AccentPhrase[]>;
   FETCH_AND_SET_ACCENT_PHRASES(payload: { audioKey: string }): void;
   FETCH_MORA_DATA(payload: {
     accentPhrases: AccentPhrase[];
-    characterIndex: number;
+    speaker: number;
   }): Promise<AccentPhrase[]>;
   FETCH_AND_COPY_MORA_DATA(payload: {
     accentPhrases: AccentPhrase[];
-    characterIndex: number;
+    speaker: number;
     copyIndexes: number[];
   }): Promise<AccentPhrase[]>;
   FETCH_AUDIO_QUERY(payload: {
     text: string;
-    characterIndex: number;
+    speaker: number;
   }): Promise<AudioQuery>;
   FETCH_AND_SET_AUDIO_QUERY(payload: { audioKey: string }): void;
   GENERATE_AUDIO(payload: { audioKey: string }): Blob | null;
@@ -169,7 +169,7 @@ export type AudioActions = {
   STOP_CONTINUOUSLY_AUDIO(): void;
   PUT_TEXTS(payload: {
     texts: string[];
-    characterIndex: number | undefined;
+    speaker: number | undefined;
     prevAudioKey: string | undefined;
   }): void[];
   OPEN_TEXT_EDIT_CONTEXT_MENU(): void;
@@ -191,10 +191,7 @@ export type AudioCommandActions = {
     prevAudioKey: string | undefined;
   }): string;
   COMMAND_REMOVE_AUDIO_ITEM(payload: { audioKey: string }): void;
-  COMMAND_CHANGE_CHARACTER_INDEX(payload: {
-    audioKey: string;
-    characterIndex: number;
-  }): void;
+  COMMAND_CHANGE_SPEAKER(payload: { audioKey: string; speaker: number }): void;
   COMMAND_CHANGE_ACCENT(payload: {
     audioKey: string;
     accentPhraseIndex: number;
@@ -259,12 +256,12 @@ export type AudioCommandMutations = {
     prevAudioKey: string | undefined;
   };
   COMMAND_REMOVE_AUDIO_ITEM: { audioKey: string };
-  COMMAND_CHANGE_CHARACTER_INDEX: {
-    characterIndex: number;
+  COMMAND_CHANGE_SPEAKER: {
+    speaker: number;
     audioKey: string;
   } & (
     | {
-        update: "CharacterIndex";
+        update: "Speaker";
       }
     | {
         update: "AccentPhrases";

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -226,9 +226,8 @@ export default defineComponent({
     );
     const addAudioItem = async () => {
       const prevAudioKey = activeAudioKey.value!;
-      const characterIndex =
-        store.state.audioItems[prevAudioKey].characterIndex;
-      const audioItem: AudioItem = { text: "", characterIndex: characterIndex };
+      const speaker = store.state.audioItems[prevAudioKey].speaker;
+      const audioItem: AudioItem = { text: "", speaker: speaker };
       const newAudioKey = await store.dispatch(COMMAND_REGISTER_AUDIO_ITEM, {
         audioItem,
         prevAudioKey: activeAudioKey.value,
@@ -272,7 +271,7 @@ export default defineComponent({
     // プロジェクトを初期化
     onMounted(async () => {
       await store.dispatch(LOAD_CHARACTER, undefined);
-      const audioItem: AudioItem = { text: "", characterIndex: 0 };
+      const audioItem: AudioItem = { text: "", speaker: 0 };
       const newAudioKey = await store.dispatch(REGISTER_AUDIO_ITEM, {
         audioItem,
       });


### PR DESCRIPTION
## 内容

AudioItemのcharaterIndexをspeakerに変更します。
https://github.com/Hiroshiba/voicevox/issues/229 のために`speakerUuidとstyleId`を用いる必要がありますが、まずは変更料が少なくて住むspeakerに変更してみました。

## 関連 Issue

ref: https://github.com/Hiroshiba/voicevox/issues/229

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

マイグレーションが一旦壊れます。
