### PR TITLE
`COMMAND_CHANGE_AUDIO_TEXT`コマンドの追加

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -41,7 +41,7 @@
       :disable="uiLocked"
       :error="audioItem.text.length >= 80"
       :model-value="audioItem.text"
-      @update:model-value="updateAudioText"
+      @update:model-value="changeAudioText"
       debounce="500"
       @keydown.prevent.enter.exact=""
       @paste="pasteOnAudioCell"
@@ -112,7 +112,7 @@ export default defineComponent({
       URL.createObjectURL(selectedCharacterInfo.value?.iconBlob)
     );
 
-    const updateAudioText = async (text: string) => {
+    const changeAudioText = async (text: string) => {
       await store.dispatch("COMMAND_CHANGE_AUDIO_TEXT", {
         audioKey: props.audioKey,
         text,
@@ -155,7 +155,7 @@ export default defineComponent({
           if (audioItem.value.text == "") {
             const text = texts.shift();
             if (text == undefined) return;
-            updateAudioText(text);
+            changeAudioText(text);
           }
 
           store.dispatch("PUT_TEXTS", {
@@ -272,7 +272,7 @@ export default defineComponent({
       nowGenerating,
       selectedCharacterInfo,
       characterIconUrl,
-      updateAudioText,
+      changeAudioText,
       changeSpeaker,
       setActiveAudioKey,
       save,

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -41,8 +41,9 @@
       :disable="uiLocked"
       :error="audioItem.text.length >= 80"
       :model-value="audioItem.text"
-      @update:model-value="setAudioText"
-      @change="willRemove || updateAudioQuery($event)"
+      @update:model-value="updateAudioText"
+      debounce="500"
+      @keydown.prevent.enter.exact=""
       @paste="pasteOnAudioCell"
       @focus="setActiveAudioKey()"
       @keydown.shift.delete.exact="removeCell"
@@ -98,9 +99,6 @@ export default defineComponent({
     );
 
     const uiLocked = computed(() => store.getters.UI_LOCKED);
-    const haveAudioQuery = computed(() =>
-      store.getters.HAVE_AUDIO_QUERY(props.audioKey)
-    );
 
     const selectedCharacterInfo = computed(() =>
       characterInfos.value != undefined && audioItem.value.speaker != undefined
@@ -114,23 +112,11 @@ export default defineComponent({
       URL.createObjectURL(selectedCharacterInfo.value?.iconBlob)
     );
 
-    // TODO: change audio textにしてvuexに載せ替える
-    const setAudioText = async (text: string) => {
-      await store.dispatch("SET_AUDIO_TEXT", {
+    const updateAudioText = async (text: string) => {
+      await store.dispatch("COMMAND_CHANGE_AUDIO_TEXT", {
         audioKey: props.audioKey,
         text,
       });
-    };
-    const updateAudioQuery = async () => {
-      if (!haveAudioQuery.value) {
-        store.dispatch("FETCH_AND_SET_AUDIO_QUERY", {
-          audioKey: props.audioKey,
-        });
-      } else {
-        store.dispatch("FETCH_AND_SET_ACCENT_PHRASES", {
-          audioKey: props.audioKey,
-        });
-      }
     };
     const changeSpeaker = (speaker: number) => {
       store.dispatch("COMMAND_CHANGE_SPEAKER", {
@@ -169,8 +155,7 @@ export default defineComponent({
           if (audioItem.value.text == "") {
             const text = texts.shift();
             if (text == undefined) return;
-            setAudioText(text);
-            updateAudioQuery();
+            updateAudioText(text);
           }
 
           store.dispatch("PUT_TEXTS", {
@@ -287,8 +272,7 @@ export default defineComponent({
       nowGenerating,
       selectedCharacterInfo,
       characterIconUrl,
-      setAudioText,
-      updateAudioQuery,
+      updateAudioText,
       changeSpeaker,
       setActiveAudioKey,
       save,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -91,6 +91,7 @@ export type AudioMutations = {
     prevAudioKey: string | undefined;
   };
   REMOVE_AUDIO_ITEM: { audioKey: string };
+  SET_AUDIO_TEXT: { audioKey: string; text: string };
   SET_AUDIO_SPEED_SCALE: { audioKey: string; speedScale: number };
   SET_AUDIO_PITCH_SCALE: { audioKey: string; pitchScale: number };
   SET_AUDIO_INTONATION_SCALE: { audioKey: string; intonationScale: number };
@@ -119,7 +120,6 @@ export type AudioMutations = {
 export type AudioActions = {
   START_WAITING_ENGINE(): void;
   LOAD_CHARACTER(): void;
-  SET_AUDIO_TEXT(payload: { audioKey: string; text: string }): void;
   REMOVE_ALL_AUDIO_ITEM(): void;
   REGISTER_AUDIO_ITEM(payload: {
     audioItem: AudioItem;
@@ -127,17 +127,12 @@ export type AudioActions = {
   }): string;
   SET_ACTIVE_AUDIO_KEY(payload: { audioKey?: string }): void;
   GET_AUDIO_CACHE(payload: { audioKey: string }): Promise<Blob | null>;
-  SET_ACCENT_PHRASES(payload: {
-    audioKey: string;
-    accentPhrases: AccentPhrase[];
-  }): void;
   SET_AUDIO_QUERY(payload: { audioKey: string; audioQuery: AudioQuery }): void;
   FETCH_ACCENT_PHRASES(payload: {
     text: string;
     speaker: number;
     isKana?: boolean;
   }): Promise<AccentPhrase[]>;
-  FETCH_AND_SET_ACCENT_PHRASES(payload: { audioKey: string }): void;
   FETCH_MORA_DATA(payload: {
     accentPhrases: AccentPhrase[];
     speaker: number;
@@ -191,6 +186,7 @@ export type AudioCommandActions = {
     prevAudioKey: string | undefined;
   }): string;
   COMMAND_REMOVE_AUDIO_ITEM(payload: { audioKey: string }): void;
+  COMMAND_CHANGE_AUDIO_TEXT(payload: { audioKey: string; text: string }): void;
   COMMAND_CHANGE_SPEAKER(payload: { audioKey: string; speaker: number }): void;
   COMMAND_CHANGE_ACCENT(payload: {
     audioKey: string;
@@ -256,6 +252,19 @@ export type AudioCommandMutations = {
     prevAudioKey: string | undefined;
   };
   COMMAND_REMOVE_AUDIO_ITEM: { audioKey: string };
+  COMMAND_CHANGE_AUDIO_TEXT: { audioKey: string; text: string } & (
+    | {
+        update: "Text";
+      }
+    | {
+        update: "AccentPhrases";
+        accentPhrases: AccentPhrase[];
+      }
+    | {
+        update: "AudioQuery";
+        query: AudioQuery;
+      }
+  );
   COMMAND_CHANGE_SPEAKER: {
     speaker: number;
     audioKey: string;


### PR DESCRIPTION
## 内容

以前のコードで`AudioCelll.vue`内でテキスト編集に用いられていた`setAudioText`, と`updateAudioQuery`を纏めてundo/redoに対応した`COMMAND_CHANGE_AUDIO_TEXT`コマンドを実装しました。

ref #258
ref #233

## 関連 Issue

ref #116

## スクリーンショット・動画など


## その他

`FETCH_AUDIO_QUERY`の発行頻度を下げるために`AudioCell`の`qinput`に`debounce`を付けた上で`enter`で確定する挙動を消しています。