### PR TITLE
Undo/Redoの記録を無効化可能に

### DIFF
--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -22,7 +22,7 @@
 
       <q-space />
       <q-btn
-        v-if="isDevelopment"
+        v-if="useUndoRedo"
         unelevated
         color="white"
         text-color="secondary"
@@ -32,7 +32,7 @@
         >元に戻す</q-btn
       >
       <q-btn
-        v-if="isDevelopment"
+        v-if="useUndoRedo"
         unelevated
         color="white"
         text-color="secondary"
@@ -73,7 +73,7 @@ export default defineComponent({
     const store = useStore();
     const $q = useQuasar();
 
-    const isDevelopment = process.env.NODE_ENV === "development";
+    const useUndoRedo = computed(() => store.state.useUndoRedo);
 
     const uiLocked = computed(() => store.getters.UI_LOCKED);
     const canUndo = computed(() => store.getters.CAN_UNDO);
@@ -114,7 +114,7 @@ export default defineComponent({
     };
 
     return {
-      isDevelopment,
+      useUndoRedo,
       uiLocked,
       canUndo,
       canRedo,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -68,6 +68,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     nowPlayingContinuously: false,
     undoCommands: [],
     redoCommands: [],
+    useUndoRedo: isDevelopment,
     useGpu: false,
     isHelpDialogOpen: false,
     isSettingDialogOpen: false,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -32,6 +32,7 @@ export type State = {
   nowPlayingContinuously: boolean;
   undoCommands: Command[];
   redoCommands: Command[];
+  useUndoRedo: boolean;
   useGpu: boolean;
   isHelpDialogOpen: boolean;
   isSettingDialogOpen: boolean;


### PR DESCRIPTION
## 内容

#233で私が実装したUndo/Redoの実装で、ImmerとVueのProxyの衝突を避けるためにState全体のコピーを撮っています。この処理はStateの大きさに従って計算コストが掛かるため製品版では問題になることが予測されます。
このプルリクエストではUndo/Redoの記録をとるかどうかのフラグをStateにおくことで、製品版ではUndo/Redoの記録をとらないようにします。

## 関連 Issue

ref #116

## スクリーンショット・動画など


## その他

実験的機能としての選択は`IMPORT_TEXT`や`PUT_TEXT`等を移行してから実装すべきだと思ったので、このプルリクエストでは実装していません。
