### PR TITLE
Linux上で外部からKillされたENGINEを再起動できない問題を修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -375,7 +375,7 @@ ipcMainHandle(
         `Restarting ENGINE (last exit code: ${engineProcess.exitCode}, signal: ${engineProcess.signalCode})`
       );
 
-      // エンジンのプロセスが存在しない（すでに終了している）場合
+      // エンジンのプロセスがすでに終了している、またはkillされている場合
       const engineExited = engineProcess.exitCode !== null;
       const engineKilled = engineProcess.signalCode !== null;
 

--- a/src/background.ts
+++ b/src/background.ts
@@ -377,8 +377,9 @@ ipcMainHandle(
 
       // エンジンのプロセスが存在しない（すでに終了している）場合
       const engineExited = engineProcess.exitCode !== null;
+      const engineKilled = engineProcess.signalCode !== null;
 
-      if (engineExited) {
+      if (engineExited || engineKilled) {
         log.info("ENGINE process is not started yet. Starting ENGINE...");
 
         runEngine();

--- a/src/background.ts
+++ b/src/background.ts
@@ -380,7 +380,9 @@ ipcMainHandle(
       const engineKilled = engineProcess.signalCode !== null;
 
       if (engineExited || engineKilled) {
-        log.info("ENGINE process is not started yet or already killed. Starting ENGINE...");
+        log.info(
+          "ENGINE process is not started yet or already killed. Starting ENGINE..."
+        );
 
         runEngine();
         resolve();

--- a/src/background.ts
+++ b/src/background.ts
@@ -380,7 +380,7 @@ ipcMainHandle(
       const engineKilled = engineProcess.signalCode !== null;
 
       if (engineExited || engineKilled) {
-        log.info("ENGINE process is not started yet. Starting ENGINE...");
+        log.info("ENGINE process is not started yet or already killed. Starting ENGINE...");
 
         runEngine();
         resolve();


### PR DESCRIPTION
## 内容

#282 から分割しました。

Linux上で、ENGINEが外部からプロセスキルされると、
VOICEVOXのUI上で「エンジンの再起動」操作（RESTART_ENGINE）が終了しない問題を修正します。

現在 5488b92e3abe919aa89713d01bea23cf8455f94e のロジックである `engineProcess.exitCode !=== null` のみでは、child_processを使って起動されたENGINEのプロセスが終了しているかどうかを完全には判定できません。

例えば、 `kill $PID` でENGINEがプロセスキルされたとき、`exitCode === null` にもかかわらず、ENGINE のプロセスは終了しているという状態になります。

このとき、RESTART_ENGINEでは、すでに終了しているENGINEのプロセスをkillしようとする動作をします。
killされているプロセスをkillしようとしても、ChildProcessの `close` イベントが起こらないため、起動処理 `runEngine()` が実行されず、「再起動」が終了しません。

ENGINEがプロセスキルされたとき、`signalCode` は設定されるため、
`signalCode !== null` を合わせてチェックすることで、この問題を修正します。

- signalCodeの例: https://nodejs.org/api/process.html#process_signal_events
- https://nodejs.org/api/child_process.html

## 実験

#281 で追加した `process.on("close", ...)` でのログ出力で、exitCode、signalCodeの挙動を確認してみました。

- Windows（`taskkill /F /PID $PID`、タスクマネージャ タスクの終了）
    - ケース1: uvicorn起動前
        - exitCode: 1
        - signalCode: null
    - ケース2: uvicorn（runのHTTPサーバ）起動後
        - exitCode: 1
        - signalCode: null
- Ubuntu（`kill $PID`）
    - ケース3: uvicorn起動前
        - exitCode: null
        - signalCode: SIGTERM
            - プロセスをkillしたあと、UIからエンジンを再起動しようとしたときにも、exitCode/signalCodeは変わらなかった
    - ケース4: uvicorn起動後
        - exitCode: 0
        - signalCode: null

ケース3では、VOICEVOXのUIからの「エンジンの再起動」操作（RESTART_ENGINE）が終了しなくなるという問題が起きます。


### 再現の流れ

1. VOICEVOXを起動する
    - 自動的にENGINEの起動が始まる
2. ENGINEのHTTPサーバが起動する前に、`kill $PID` でENGINEをプロセスキルする
3. VOICEVOXのUI上で「エンジンの再起動」（RESTART_ENGINE）操作をする
4. 「エンジン起動中・・・」が表示される（ENGINEをkillしようと試みる）
    - ENGINEはすでにkillされている
    - プロセスがすでに終了しているため、ChildProcessの `close` イベントが起こらない
    - `runEngine()` が実行されない
5. 「エンジンの再起動」操作が終わらない
    - エンジンの再起動には、VOICEVOXを終了し、再起動する必要がある


### ケース3が起きる状況の例

- killコマンド `kill $PID`
- OOM Killer（OS側のメモリ確保機能、挙動はよくわからない）


## 関連 Issue

ref #282 
ref #270 
