### PR TITLE
Storeのactions/mutationsのundefined引数を消す

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -215,7 +215,7 @@ export default defineComponent({
 
     // テキスト編集エリアの右クリック
     const onRightClickTextField = () => {
-      store.dispatch("OPEN_TEXT_EDIT_CONTEXT_MENU", undefined);
+      store.dispatch("OPEN_TEXT_EDIT_CONTEXT_MENU");
     };
 
     // 下にセルを追加

--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -83,14 +83,14 @@ export default defineComponent({
     );
 
     const undo = () => {
-      store.dispatch("UNDO", undefined);
+      store.dispatch("UNDO");
     };
     const redo = () => {
-      store.dispatch("REDO", undefined);
+      store.dispatch("REDO");
     };
     const playContinuously = async () => {
       try {
-        await store.dispatch("PLAY_CONTINUOUSLY_AUDIO", undefined);
+        await store.dispatch("PLAY_CONTINUOUSLY_AUDIO");
       } catch {
         $q.dialog({
           title: "再生に失敗しました",
@@ -104,7 +104,7 @@ export default defineComponent({
       }
     };
     const stopContinuously = () => {
-      store.dispatch("STOP_CONTINUOUSLY_AUDIO", undefined);
+      store.dispatch("STOP_CONTINUOUSLY_AUDIO");
     };
     const openHelpDialog = () => {
       store.dispatch("IS_HELP_DIALOG_OPEN", { isHelpDialogOpen: true });

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -169,7 +169,7 @@ export default defineComponent({
           {
             type: "button",
             label: "再起動",
-            onClick: () => store.dispatch("RESTART_ENGINE", undefined),
+            onClick: () => store.dispatch("RESTART_ENGINE"),
           },
         ],
       },

--- a/src/components/OssLicense.vue
+++ b/src/components/OssLicense.vue
@@ -51,9 +51,7 @@ export default defineComponent({
     const store = useStore();
 
     let licenses = ref<Record<string, string>[]>();
-    store
-      .dispatch("GET_OSS_LICENSES", undefined)
-      .then((obj) => (licenses.value = obj));
+    store.dispatch("GET_OSS_LICENSES").then((obj) => (licenses.value = obj));
 
     const detailIndex = ref<number | undefined>(undefined);
 

--- a/src/components/Policy.vue
+++ b/src/components/Policy.vue
@@ -26,9 +26,7 @@ export default defineComponent({
     const md = useMarkdownIt();
 
     onMounted(async () => {
-      policy.value = md.render(
-        await store.dispatch("GET_POLICY_TEXT", undefined)
-      );
+      policy.value = md.render(await store.dispatch("GET_POLICY_TEXT"));
     });
 
     return {

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -201,7 +201,7 @@ export default defineComponent({
 
       const change = async () => {
         await store.dispatch("SET_USE_GPU", { useGpu });
-        store.dispatch("RESTART_ENGINE", undefined);
+        store.dispatch("RESTART_ENGINE");
 
         $q.dialog({
           title: "エンジンの起動モードを変更しました",
@@ -256,7 +256,7 @@ export default defineComponent({
     };
 
     const restartEngineProcess = () => {
-      store.dispatch("RESTART_ENGINE", undefined);
+      store.dispatch("RESTART_ENGINE");
     };
 
     const savingSetting = computed(() => store.state.savingSetting);
@@ -279,7 +279,7 @@ export default defineComponent({
     };
 
     onUpdated(() => {
-      store.dispatch("GET_SAVING_SETTING_DATA", undefined);
+      store.dispatch("GET_SAVING_SETTING_DATA");
     });
 
     return {

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -25,9 +25,7 @@ export default defineComponent({
     const store = useStore();
 
     const infos = ref<UpdateInfo[]>();
-    store
-      .dispatch("GET_UPDATE_INFOS", undefined)
-      .then((obj) => (infos.value = obj));
+    store.dispatch("GET_UPDATE_INFOS").then((obj) => (infos.value = obj));
 
     const html = computed(() => {
       if (!infos.value) return "";

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -726,8 +726,8 @@ export const audioStore: VoiceVoxStoreOptions<
       await commit("SET_ENGINE_STATE", { engineState: "STARTING" });
       window.electron
         .restartEngine()
-        .then(() => dispatch("START_WAITING_ENGINE", undefined))
-        .catch(() => dispatch("DETECTED_ENGINE_ERROR", undefined));
+        .then(() => dispatch("START_WAITING_ENGINE"))
+        .catch(() => dispatch("DETECTED_ENGINE_ERROR"));
     },
     CHECK_FILE_EXISTS(_, { file }: { file: string }) {
       return window.electron.checkFileExists(file);

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -204,10 +204,10 @@ export const commandStore: VoiceVoxStoreOptions<
 
   actions: {
     UNDO({ commit }) {
-      commit("UNDO", undefined);
+      commit("UNDO");
     },
     REDO({ commit }) {
-      commit("REDO", undefined);
+      commit("REDO");
     },
   },
 };

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -18,9 +18,9 @@ export function createUILockAction<S, A extends ActionsBase, K extends keyof A>(
     : Promise<ReturnType<A[K]>>
 ): Action<S, S, A, K, AllGetters, AllActions, AllMutations> {
   return (context, payload: Parameters<A[K]>[0]) => {
-    context.commit("LOCK_UI", undefined);
+    context.commit("LOCK_UI");
     return action(context, payload).finally(() => {
-      context.commit("UNLOCK_UI", undefined);
+      context.commit("UNLOCK_UI");
     });
   };
 }
@@ -74,10 +74,10 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
 
     actions: {
       LOCK_UI({ commit }) {
-        commit("LOCK_UI", undefined);
+        commit("LOCK_UI");
       },
       UNLOCK_UI({ commit }) {
-        commit("UNLOCK_UI", undefined);
+        commit("UNLOCK_UI");
       },
       ASYNC_UI_LOCK: createUILockAction(
         async (_, { callback }: { callback: () => Promise<void> }) => {
@@ -90,8 +90,8 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       ) {
         if (state.isHelpDialogOpen === isHelpDialogOpen) return;
 
-        if (isHelpDialogOpen) commit("LOCK_UI", undefined);
-        else commit("UNLOCK_UI", undefined);
+        if (isHelpDialogOpen) commit("LOCK_UI");
+        else commit("UNLOCK_UI");
 
         commit("IS_HELP_DIALOG_OPEN", { isHelpDialogOpen });
       },
@@ -101,8 +101,8 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
       ) {
         if (state.isSettingDialogOpen === isSettingDialogOpen) return;
 
-        if (isSettingDialogOpen) commit("LOCK_UI", undefined);
-        else commit("UNLOCK_UI", undefined);
+        if (isSettingDialogOpen) commit("LOCK_UI");
+        else commit("UNLOCK_UI");
 
         commit("IS_SETTING_DIALOG_OPEN", { isSettingDialogOpen });
       },
@@ -117,16 +117,16 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
         });
       },
       async DETECT_UNMAXIMIZED({ commit }) {
-        commit("DETECT_UNMAXIMIZED", undefined);
+        commit("DETECT_UNMAXIMIZED");
       },
       async DETECT_MAXIMIZED({ commit }) {
-        commit("DETECT_MAXIMIZED", undefined);
+        commit("DETECT_MAXIMIZED");
       },
       async DETECT_PINNED({ commit }) {
-        commit("DETECT_PINNED", undefined);
+        commit("DETECT_PINNED");
       },
       async DETECT_UNPINNED({ commit }) {
-        commit("DETECT_UNPINNED", undefined);
+        commit("DETECT_UNPINNED");
       },
     },
   };

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -3,8 +3,6 @@ import {
   Store as BaseStore,
   createStore as baseCreateStore,
   useStore as baseUseStore,
-  DispatchOptions,
-  CommitOptions,
   ModuleTree,
   Plugin,
   StoreOptions as OriginalStoreOptions,
@@ -68,11 +66,9 @@ export function useStore<
 }
 
 export interface Dispatch<A extends ActionsBase> {
-  <T extends keyof A>(
-    type: T,
-    payload: Parameters<A[T]>[0],
-    options?: DispatchOptions
-  ): Promise<PromiseType<ReturnType<A[T]>>>;
+  <T extends keyof A>(type: T, payload: Parameters<A[T]>[0]): Promise<
+    PromiseType<ReturnType<A[T]>>
+  >;
   <T extends keyof A>(
     payloadWithType: { type: T } & (Parameters<A[T]>[0] extends Record<
       string,
@@ -80,19 +76,17 @@ export interface Dispatch<A extends ActionsBase> {
     >
       ? Parameters<A[T]>[0]
       : // eslint-disable-next-line @typescript-eslint/ban-types
-        {}),
-    options?: DispatchOptions
+        {})
   ): Promise<PromiseType<ReturnType<A[T]>>>;
 }
 
 export interface Commit<M extends MutationsBase> {
-  <T extends keyof M>(type: T, payload: M[T], options?: CommitOptions): void;
+  <T extends keyof M>(type: T, payload: M[T]): void;
   <T extends keyof M>(
     payloadWithType: { type: T } & (M[T] extends Record<string, any>
       ? M[T]
       : // eslint-disable-next-line @typescript-eslint/ban-types
-        {}),
-    options?: CommitOptions
+        {})
   ): void;
 }
 

--- a/src/store/vuex.ts
+++ b/src/store/vuex.ts
@@ -66,9 +66,12 @@ export function useStore<
 }
 
 export interface Dispatch<A extends ActionsBase> {
-  <T extends keyof A>(type: T, payload: Parameters<A[T]>[0]): Promise<
-    PromiseType<ReturnType<A[T]>>
-  >;
+  <T extends keyof A>(
+    type: T,
+    ...payload: Parameters<A[T]>[0] extends undefined
+      ? void[]
+      : [Parameters<A[T]>[0]]
+  ): Promise<PromiseType<ReturnType<A[T]>>>;
   <T extends keyof A>(
     payloadWithType: { type: T } & (Parameters<A[T]>[0] extends Record<
       string,
@@ -81,7 +84,10 @@ export interface Dispatch<A extends ActionsBase> {
 }
 
 export interface Commit<M extends MutationsBase> {
-  <T extends keyof M>(type: T, payload: M[T]): void;
+  <T extends keyof M>(
+    type: T,
+    ...payload: M[T] extends undefined ? void[] : [M[T]]
+  ): void;
   <T extends keyof M>(
     payloadWithType: { type: T } & (M[T] extends Record<string, any>
       ? M[T]

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -255,7 +255,7 @@ export default defineComponent({
 
     // プロジェクトを初期化
     onMounted(async () => {
-      await store.dispatch("LOAD_CHARACTER", undefined);
+      await store.dispatch("LOAD_CHARACTER");
       const audioItem: AudioItem = { text: "", speaker: 0 };
       const newAudioKey = await store.dispatch("REGISTER_AUDIO_ITEM", {
         audioItem,


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
Storeの厳密な型付けの過程で必要になってしまっていた`undefined`を消せるような型に書き直し、消しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- #197 
- #273 
- #277 

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

ただし、この変更によって一部機能が無効化されました(`DispatchOptions`と`CommitOptions`を型的に使えなくしました)。
現状使われておらず、かつ今後使われる予定もないと思われるのでいったん無効化しましたが、必要であればもう少し頑張って型を復旧します。

また、一部環境において型推論が壊れます(私の開発環境のWebStormでは型推論がおかしくなり、型を正しく認識してくれませんでした...が、VS Codeでは問題なかったのでたぶん大丈夫でしょう...)
