### PR TITLE
`PUT_TEXTS`のコマンドへの移行

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -152,17 +152,13 @@ export default defineComponent({
           blurCell(); // フォーカスを外して編集中のテキスト内容を確定させる
 
           const prevAudioKey = props.audioKey;
-          if (audioItem.value.text == "") {
-            const text = texts.shift();
-            if (text == undefined) return;
-            changeAudioText(text);
-          }
-
-          store.dispatch("COMMAND_PUT_TEXTS", {
+          const audioKeys = await store.dispatch("COMMAND_PUT_TEXTS", {
             texts,
             speaker: audioItem.value.speaker!,
             prevAudioKey,
           });
+          if (audioKeys)
+            emit("focusCell", { audioKey: audioKeys[audioKeys.length - 1] });
         }
       }
     };

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -152,6 +152,12 @@ export default defineComponent({
           blurCell(); // フォーカスを外して編集中のテキスト内容を確定させる
 
           const prevAudioKey = props.audioKey;
+          if (audioItem.value.text == "") {
+            const text = texts.shift();
+            if (text == undefined) return;
+            changeAudioText(text);
+          }
+
           const audioKeys = await store.dispatch("COMMAND_PUT_TEXTS", {
             texts,
             speaker: audioItem.value.speaker!,

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -158,9 +158,9 @@ export default defineComponent({
             changeAudioText(text);
           }
 
-          store.dispatch("PUT_TEXTS", {
+          store.dispatch("COMMAND_PUT_TEXTS", {
             texts,
-            speaker: audioItem.value.speaker,
+            speaker: audioItem.value.speaker!,
             prevAudioKey,
           });
         }

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -151,6 +151,30 @@ export const audioStore: VoiceVoxStoreOptions<
         nowGenerating: false,
       };
     },
+    INSERT_AUDIO_ITEMS(
+      state,
+      {
+        prevAudioKey,
+        audioKeyItemPairs,
+      }: {
+        audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
+        prevAudioKey: string | undefined;
+      }
+    ) {
+      const index =
+        prevAudioKey !== undefined
+          ? state.audioKeys.indexOf(prevAudioKey) + 1
+          : state.audioKeys.length;
+      const audioKeys = audioKeyItemPairs.map((pair) => pair.audioKey);
+      state.audioKeys.splice(index, 0, ...audioKeys);
+      for (const { audioKey, audioItem } of audioKeyItemPairs) {
+        state.audioItems[audioKey] = audioItem;
+        state.audioStates[audioKey] = {
+          nowPlaying: false,
+          nowGenerating: false,
+        };
+      }
+    },
     REMOVE_AUDIO_ITEM(state, { audioKey }: { audioKey: string }) {
       state.audioKeys.splice(state.audioKeys.indexOf(audioKey), 1);
       delete state.audioItems[audioKey];
@@ -1285,31 +1309,25 @@ export const audioCommandStore: VoiceVoxStoreOptions<
         audioKeyItemPairs,
       }: { audioKeyItemPairs: { audioKey: string; audioItem: AudioItem }[] }
     ) {
-      for (const { audioKey, audioItem } of audioKeyItemPairs) {
-        audioStore.mutations.INSERT_AUDIO_ITEM(draft, {
-          audioKey: audioKey,
-          audioItem: audioItem,
-          prevAudioKey: undefined,
-        });
-      }
+      audioStore.mutations.INSERT_AUDIO_ITEMS(draft, {
+        audioKeyItemPairs,
+        prevAudioKey: undefined,
+      });
     },
     COMMAND_PUT_TEXTS(
       draft,
-      payload: {
+      {
+        audioKeyItemPairs,
+        prevAudioKey,
+      }: {
         audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
         prevAudioKey: string;
       }
     ) {
-      let prevAudioKey = payload.prevAudioKey;
-
-      for (const { audioKey, audioItem } of payload.audioKeyItemPairs) {
-        audioStore.mutations.INSERT_AUDIO_ITEM(draft, {
-          audioKey,
-          audioItem,
-          prevAudioKey,
-        });
-        prevAudioKey = audioKey;
-      }
+      audioStore.mutations.INSERT_AUDIO_ITEMS(draft, {
+        audioKeyItemPairs,
+        prevAudioKey,
+      });
     },
   }),
 };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -91,6 +91,10 @@ export type AudioMutations = {
     audioKey: string;
     prevAudioKey: string | undefined;
   };
+  INSERT_AUDIO_ITEMS: {
+    audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
+    prevAudioKey: string | undefined;
+  };
   REMOVE_AUDIO_ITEM: { audioKey: string };
   SET_AUDIO_TEXT: { audioKey: string; text: string };
   SET_AUDIO_SPEED_SCALE: { audioKey: string; speedScale: number };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -162,11 +162,6 @@ export type AudioActions = {
   STOP_AUDIO(payload: { audioKey: string }): void;
   PLAY_CONTINUOUSLY_AUDIO(): void;
   STOP_CONTINUOUSLY_AUDIO(): void;
-  PUT_TEXTS(payload: {
-    texts: string[];
-    speaker: number | undefined;
-    prevAudioKey: string | undefined;
-  }): void[];
   OPEN_TEXT_EDIT_CONTEXT_MENU(): void;
   DETECTED_ENGINE_ERROR(): void;
   RESTART_ENGINE(): void;
@@ -244,6 +239,11 @@ export type AudioCommandActions = {
     postPhonemeLength: number;
   }): void;
   COMMAND_IMPORT_FROM_FILE(payload: { filePath?: string }): string[] | void;
+  COMMAND_PUT_TEXTS(payload: {
+    prevAudioKey: string;
+    texts: string[];
+    speaker: number;
+  }): string[];
 };
 
 export type AudioCommandMutations = {
@@ -318,6 +318,10 @@ export type AudioCommandMutations = {
   };
   COMMAND_IMPORT_FROM_FILE: {
     audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
+  };
+  COMMAND_PUT_TEXTS: {
+    audioKeyItemPairs: { audioItem: AudioItem; audioKey: string }[];
+    prevAudioKey: string;
   };
 };
 


### PR DESCRIPTION
## 内容

`audioStore`上にあった`PUT_TEXTS`アクションをコマンド化し`COMMAND_PUT_TEXTS`として実装し直しました。
これによってペースト処理がUNDO/REDOのHistoryに記録されるようになります。

また、#284 でqinputにdebounceが付いたことにより、Storeの値が古くなることがあったためセルが空文字列("")の時にそのセルを上書きする処理を無効化しました。
追加したコマンドはActionが追加した`audioKey`の配列を返すのでペーストした最後の要素にフォーカスするようにしました。

ref #258
ref #233

## 関連 Issue

ref #116

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
