### PR TITLE
undo/redoのパフォーマンス改善

### DIFF
--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -1,5 +1,5 @@
 import { Action, Store } from "vuex";
-
+import { toRaw } from "vue";
 import { enablePatches, enableMapSet, Patch, Draft, Immer } from "immer";
 import { applyPatch, Operation } from "rfc6902";
 import {
@@ -160,7 +160,7 @@ const recordOperations =
     const [_, doPatches, undoPatches] = immer.produceWithPatches(
       // Taking snapshots has negative effects on performance.
       // This approach may cause a bottleneck.
-      JSON.parse(JSON.stringify(state)) as S,
+      toRaw(state) as S,
       (draft: S) => recipe(draft, payload)
     );
     return {

--- a/src/store/command.ts
+++ b/src/store/command.ts
@@ -101,8 +101,6 @@ interface UndoRedoState {
 
 /**
  * レシピをプロパティに持つオブジェクトから操作を記録するMutationをプロパティにもつオブジェクトを返す関数
- * @see {@link recordOperations} - 返されるMutationはStateのスナップショットを撮ります.
- * これはパフォーマンス上のボトルネックを引き起こし得ます。
  * @param payloadRecipeTree - レシピをプロパティに持つオブジェクト
  * @returns Mutationを持つオブジェクト(MutationTree)
  */
@@ -121,8 +119,6 @@ export const createCommandMutationTree = <
 
 /**
  * 与えられたレシピから操作を記録し実行後にStateに追加するMutationを返す。
- * @see {@link recordOperations} - 返されるMutationはStateのスナップショットを撮ります.
- * これはパフォーマンス上のボトルネックを引き起こし得ます。
  * @param payloadRecipe - 操作を記録するレシピ
  * @returns レシピと同じPayloadの型を持つMutation.
  */
@@ -148,7 +144,6 @@ const patchToOperation = (patch: Patch): Operation => ({
 });
 
 /**
- * この関数はStateのスナップショットを撮ります. これはパフォーマンス上のボトルネックを引き起こし得ます。
  * @param recipe - 操作を記録したいレシピ関数
  * @returns Function - レシピの操作を与えられたstateとpayloadを用いて記録したコマンドを返す関数。
  */
@@ -158,8 +153,6 @@ const recordOperations =
   ) =>
   (state: S, payload: P): Command => {
     const [_, doPatches, undoPatches] = immer.produceWithPatches(
-      // Taking snapshots has negative effects on performance.
-      // This approach may cause a bottleneck.
       toRaw(state) as S,
       (draft: S) => recipe(draft, payload)
     );


### PR DESCRIPTION
## 内容

#233 で追加したUNDO/REDOの実装方式はVueとImmerのProxyの衝突を避けるためにState全体のスナップショットを撮るためパフォーマンス上のボトルネックになっていました。
このプルリクエストはUNDO/REDOの記録の為にVueのProxyを外す方法を`JSON.parse(JSON.stringfy((state))`からVueの`toRaw`関数に変更し、パフォーマンスを改善しました。

## 関連 Issue

ref #116

## スクリーンショット・動画など

## その他
