### PR TITLE
AudioCellのEnterの挙動を前バージョンのものに修正/テキストのフラッシュを改良

### DIFF
--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -39,11 +39,10 @@
       hide-bottom-space
       class="full-width"
       :disable="uiLocked"
-      :error="audioItem.text.length >= 80"
-      :model-value="audioItem.text"
-      @update:model-value="changeAudioText"
-      debounce="500"
-      @keydown.prevent.enter.exact=""
+      :error="audioTextBuffer.length >= 80"
+      :model-value="audioTextBuffer"
+      @update:model-value="setAudioTextBuffer"
+      @change="willRemove || pushAudioText($event)"
       @paste="pasteOnAudioCell"
       @focus="setActiveAudioKey()"
       @keydown.shift.delete.exact="removeCell"
@@ -72,7 +71,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, onMounted, ref } from "vue";
+import { computed, watch, defineComponent, onMounted, ref } from "vue";
 import { useStore } from "@/store";
 import { AudioItem } from "@/store/type";
 import { CharacterInfo } from "@/type/preload";
@@ -112,12 +111,31 @@ export default defineComponent({
       URL.createObjectURL(selectedCharacterInfo.value?.iconBlob)
     );
 
-    const changeAudioText = async (text: string) => {
-      await store.dispatch("COMMAND_CHANGE_AUDIO_TEXT", {
-        audioKey: props.audioKey,
-        text,
-      });
+    const audioTextBuffer = ref(audioItem.value.text);
+    const isChangeFlag = ref(false);
+    const setAudioTextBuffer = (text: string) => {
+      audioTextBuffer.value = text;
+      isChangeFlag.value = true;
     };
+    watch(
+      () => audioItem.value?.text,
+      (newText) => {
+        if (!isChangeFlag.value && newText !== undefined) {
+          audioTextBuffer.value = newText;
+        }
+      }
+    );
+
+    const pushAudioText = async (text: string) => {
+      if (isChangeFlag.value) {
+        isChangeFlag.value = false;
+        await store.dispatch("COMMAND_CHANGE_AUDIO_TEXT", {
+          audioKey: props.audioKey,
+          text: audioTextBuffer.value,
+        });
+      }
+    };
+
     const changeSpeaker = (speaker: number) => {
       store.dispatch("COMMAND_CHANGE_SPEAKER", {
         audioKey: props.audioKey,
@@ -152,10 +170,11 @@ export default defineComponent({
           blurCell(); // フォーカスを外して編集中のテキスト内容を確定させる
 
           const prevAudioKey = props.audioKey;
-          if (audioItem.value.text == "") {
+          if (audioTextBuffer.value == "") {
             const text = texts.shift();
             if (text == undefined) return;
-            changeAudioText(text);
+            setAudioTextBuffer(text);
+            await pushAudioText(text);
           }
 
           store.dispatch("PUT_TEXTS", {
@@ -272,7 +291,9 @@ export default defineComponent({
       nowGenerating,
       selectedCharacterInfo,
       characterIconUrl,
-      changeAudioText,
+      audioTextBuffer,
+      setAudioTextBuffer,
+      pushAudioText,
       changeSpeaker,
       setActiveAudioKey,
       save,

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -118,6 +118,7 @@ export default defineComponent({
       isChangeFlag.value = true;
     };
     watch(
+      // `audioItem` becomes undefined just before the component is unmounted.
       () => audioItem.value?.text,
       (newText) => {
         if (!isChangeFlag.value && newText !== undefined) {


### PR DESCRIPTION
## 内容

#284 でAudioCellに入った仕様変更を元に戻し、EnterでAccentPhrasesを確定する挙動に修正しました。
この変更に伴い、IMEで入力中のテキストがフラッシュする挙動が改善されました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など


## その他
