### PR TITLE
Edited判定・プロジェクト破棄のダイアログ表示

### DIFF
--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -10,10 +10,13 @@
       @mouseover="reassignSubMenuOpen(i)"
     />
     <q-space />
-    <div v-if="projectName !== undefined" class="window-title">
-      {{ projectName + " - VOICEVOX" }}
+    <div class="window-title">
+      {{
+        (isEdited ? "*" : "") +
+        (projectName !== undefined ? projectName + " - " : "") +
+        "VOICEVOX"
+      }}
     </div>
-    <div v-else class="window-title">VOICEVOX</div>
     <q-space />
     <title-bar-buttons />
   </q-bar>
@@ -71,6 +74,7 @@ export default defineComponent({
 
     const uiLocked = computed(() => store.getters.UI_LOCKED);
     const projectName = computed(() => store.getters.PROJECT_NAME);
+    const isEdited = computed(() => store.getters.IS_EDITED);
 
     const menudata = ref<MenuItemData[]>([
       {
@@ -217,6 +221,7 @@ export default defineComponent({
     return {
       uiLocked,
       projectName,
+      isEdited,
       subMenuOpenFlags,
       reassignSubMenuOpen,
       menudata,

--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -150,14 +150,27 @@ import { mdiWindowRestore } from "@quasar/extras/mdi-v5";
 export default defineComponent({
   name: "TitleBarButtons",
   setup() {
-    const closeWindow = () => window.electron.closeWindow();
+    const store = useStore();
+
+    const closeWindow = async () => {
+      if (
+        store.getters.IS_EDITED &&
+        !(await window.electron.showConfirmDialog({
+          title: "警告",
+          message:
+            "プロジェクトの変更が保存されていません。\n" +
+            "変更を破棄してもよろしいですか？",
+        }))
+      ) {
+        return;
+      }
+      window.electron.closeWindow();
+    };
     const minimizeWindow = () => window.electron.minimizeWindow();
     const maximizeWindow = () => window.electron.maximizeWindow();
     const changePinWindow = () => {
       window.electron.changePinWindow();
     };
-
-    const store = useStore();
 
     const isPinned = computed(() => store.state.isPinned);
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -73,6 +73,7 @@ export const store = createStore<State, AllGetters, AllActions, AllMutations>({
     isHelpDialogOpen: false,
     isSettingDialogOpen: false,
     isMaximized: false,
+    savedProjectHistory: [],
     savingSetting: {
       fileEncoding: "UTF-8",
       fixedExportEnabled: false,

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -38,6 +38,7 @@ export type State = {
   isSettingDialogOpen: boolean;
   isMaximized: boolean;
   projectFilePath?: string;
+  savedProjectHistory: { name: string; unixMillisec: number }[];
   savingSetting: SavingSetting;
   isPinned: boolean;
 };
@@ -54,6 +55,8 @@ export type AudioState = {
 };
 
 export type Command = {
+  name: string;
+  unixMillisec: number;
   undoOperations: Operation[];
   redoOperations: Operation[];
 };
@@ -336,6 +339,7 @@ export type AudioCommandMutations = {
 export type CommandGetters = {
   CAN_UNDO: boolean;
   CAN_REDO: boolean;
+  HISTORY: { name: string; unixMillisec: number }[];
 };
 
 export type CommandMutations = {
@@ -378,10 +382,12 @@ export type IndexActions = {
 
 export type ProjectGetters = {
   PROJECT_NAME: string | undefined;
+  IS_EDITED: boolean;
 };
 
 export type ProjectMutations = {
   SET_PROJECT_FILEPATH: { filePath?: string };
+  SET_SAVEDHISTORY: { name: string; unixMillisec: number }[];
 };
 
 export type ProjectActions = {

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -30,6 +30,7 @@ describe("store/vuex.js test", () => {
         isHelpDialogOpen: false,
         isSettingDialogOpen: false,
         isMaximized: false,
+        savedProjectHistory: [],
         savingSetting: {
           fileEncoding: "UTF-8",
           fixedExportEnabled: false,


### PR DESCRIPTION
## 内容
プロジェクトを開いてから現状までのコマンド列を記憶してプロジェクトに変更が起こったか判定する

1. プロジェクトに変更を加えたときにタイトルバーに * を付ける
2. UndoしてすぐRedo, なにかしてすぐUndoは変更とみなさない (VSCodeを参考にした)
3. プロジェクトの変更が保存されておらず、以下のアクションが起こった時に確認ダイアログを表示する

  * 新規プロジェクト (常に聞かれていたものを変更時のみ聞くように変更)
  * プロジェクトを開く (常に聞かれていたものを変更時のみ聞くように変更)
  * ウィンドウを閉じる (新しく実装 #117 )

## 関連 Issue

Close #117 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
実装したHISTORYはお絵かきソフトによくある履歴表示に役立つかも...