### PR TITLE
CPU版自動ビルドを有効化

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,18 +28,43 @@ jobs:
       matrix:
         artifact_name:
           - linux-noengine-prepackage
+          - linux-noengine-cpu-prepackage
           - windows-noengine-prepackage
+          - windows-noengine-cpu-prepackage
         include:
           - artifact_name: linux-noengine-prepackage
             artifact_path: dist_electron/linux-unpacked
+            package_name: voicevox
+            product_name: VOICEVOX
+            os: ubuntu-18.04
+          - artifact_name: linux-noengine-cpu-prepackage
+            artifact_path: dist_electron/linux-unpacked
+            package_name: voicevox-cpu
+            product_name: VOICEVOX CPU
             os: ubuntu-18.04
           - artifact_name: windows-noengine-prepackage
             artifact_path: dist_electron/win-unpacked
+            package_name: voicevox
+            product_name: VOICEVOX
+            os: windows-2019
+          - artifact_name: windows-noengine-cpu-prepackage
+            artifact_path: dist_electron/win-unpacked
+            package_name: voicevox-cpu
+            product_name: VOICEVOX CPU
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
+
+      # Rename executable file
+      - name: Replace package name
+        shell: bash
+        run: |
+          # GPU: "name": "voicevox" => "name": "voicevox"
+          # CPU: "name": "voicevox" => "name": "voicevox-cpu"
+          sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
+          sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
 
       - name: Set output Node version
         id: node-version
@@ -134,13 +159,13 @@ jobs:
           - windows-nvidia-prepackage
         include:
           - artifact_name: linux-cpu-prepackage
-            noengine_artifact_name: linux-noengine-prepackage
+            noengine_artifact_name: linux-noengine-cpu-prepackage
             voicevox_engine_asset_name: linux-cpu
           - artifact_name: linux-nvidia-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
           - artifact_name: windows-cpu-prepackage
-            noengine_artifact_name: windows-noengine-prepackage
+            noengine_artifact_name: windows-noengine-cpu-prepackage
             voicevox_engine_asset_name: windows-cpu
           - artifact_name: windows-nvidia-prepackage
             noengine_artifact_name: windows-noengine-prepackage
@@ -352,12 +377,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      # If the CPU/GPU builds have the same package name,
-      # the NSIS installers and the 7z files have duplicate names.
-      # For Linux, If they have the same product name,
-      # the AppImages have duplicate names.
-      # Files with the same name cannot be uploaded to a single GitHub Release,
-      # so different package/product names should be used for CPU/GPU builds.
+      # NOTE: If the CPU/GPU builds have the same package name,
+      #       the NSIS installers and the 7z files have duplicate names.
+      #       For Linux, If they have the same product name,
+      #       the AppImages have duplicate names.
+      #       Files with the same name cannot be uploaded to a single GitHub Release,
+      #       so different package/product names should be used for CPU/GPU builds.
       - name: Replace package name
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,18 +330,22 @@ jobs:
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
             package_name: voicevox-cpu
+            product_name: VOICEVOX CPU
             os: ubuntu-18.04
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
             package_name: voicevox
+            product_name: VOICEVOX
             os: ubuntu-18.04
           - artifact_name: windows-cpu-nsis-web
             engine_artifact_name: windows-cpu-prepackage
             package_name: voicevox-cpu
+            product_name: VOICEVOX CPU
             os: windows-2019
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
             package_name: voicevox
+            product_name: VOICEVOX
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
@@ -349,15 +353,18 @@ jobs:
       - uses: actions/checkout@master
 
       # If the CPU/GPU builds have the same package name,
-      # the NSIS installer and the 7z files have duplicate names.
+      # the NSIS installers and the 7z files have duplicate names.
+      # For Linux, If they have the same product name,
+      # the AppImages have duplicate names.
       # Files with the same name cannot be uploaded to a single GitHub Release,
-      # so different package names should be used for CPU/GPU builds.
+      # so different package/product names should be used for CPU/GPU builds.
       - name: Replace package name
         shell: bash
         run: |
           # GPU: "name": "voicevox" => "name": "voicevox"
           # CPU: "name": "voicevox" => "name": "voicevox-cpu"
           sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
+          sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
 
       - name: Download and extract engine-prepackage artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -306,7 +306,7 @@ jobs:
         if: startsWith(matrix.artifact_name, 'linux-') # linux
         shell: bash
         run: |
-          chmod +x prepackage/${{ matrix.package_name }}
+          chmod +x prepackage/${{ matrix.linux_executable_name }}
           chmod +x prepackage/run
 
       - name: Set BUILD_IDENTIFIER env var
@@ -421,7 +421,7 @@ jobs:
         if: endsWith(matrix.artifact_name, '-appimage') # linux
         shell: bash
         run: |
-          chmod +x prepackage/${{ matrix.package_name }}
+          chmod +x prepackage/${{ matrix.linux_executable_name }}
           chmod +x prepackage/run
 
       - name: Show disk space (debug info)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,7 +329,7 @@ jobs:
         include:
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
-            package_name: voicevox_cpu
+            package_name: voicevox-cpu
             os: ubuntu-18.04
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
@@ -337,7 +337,7 @@ jobs:
             os: ubuntu-18.04
           - artifact_name: windows-cpu-nsis-web
             engine_artifact_name: windows-cpu-prepackage
-            package_name: voicevox_cpu
+            package_name: voicevox-cpu
             os: windows-2019
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
@@ -356,7 +356,7 @@ jobs:
         shell: bash
         run: |
           # GPU: "name": "voicevox" => "name": "voicevox"
-          # CPU: "name": "voicevox" => "name": "voicevox_cpu"
+          # CPU: "name": "voicevox" => "name": "voicevox-cpu"
           sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
 
       - name: Download and extract engine-prepackage artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -292,7 +292,7 @@ jobs:
         if: startsWith(matrix.artifact_name, 'linux-') # linux
         shell: bash
         run: |
-          chmod +x prepackage/voicevox
+          chmod +x prepackage/${{ matrix.package_name }}
           chmod +x prepackage/run
 
       - name: Set BUILD_IDENTIFIER env var
@@ -401,7 +401,7 @@ jobs:
         if: endsWith(matrix.artifact_name, '-appimage') # linux
         shell: bash
         run: |
-          chmod +x prepackage/voicevox
+          chmod +x prepackage/${{ matrix.package_name }}
           chmod +x prepackage/run
 
       - name: Show disk space (debug info)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -534,9 +534,9 @@ jobs:
             7z -v1g a "${appImageFile}.7z" "${appImageFile}"
 
             # Output splitted archive name<TAB>size<TAB>hash list to myartifact.7z.txt
-            ls ${appImageFile}.7z.* > archives_name.txt
-            stat --printf="%s\n" *.7z.* > archives_size.txt
-            md5sum *.7z.* | awk '{print $1}' | tr a-z A-Z > archives_hash.txt
+            ls "${appImageFile}.7z".* > archives_name.txt
+            stat --printf="%s\n" "${appImageFile}.7z".* > archives_size.txt
+            md5sum "${appImageFile}.7z".* | awk '{print $1}' | tr a-z A-Z > archives_hash.txt
 
             paste -d '\t' archives_name.txt archives_size.txt archives_hash.txt > archives.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -520,7 +520,9 @@ jobs:
           - windows-cpu-nsis-web
         include:
           - artifact_name: linux-nvidia-appimage
+            appimage_7z_name: VOICEVOX.AppImage
           - artifact_name: linux-cpu-appimage
+            appimage_7z_name: VOICEVOX-CPU.AppImage
           - artifact_name: windows-nvidia-nsis-web
           - artifact_name: windows-cpu-nsis-web
 
@@ -557,12 +559,12 @@ jobs:
             echo "Splitting ${appImageFile}"
 
             # compressed to MyArtifact.AppImage.7z.001, MyArtifact.AppImage.7z.002, ...
-            7z -v1g a "${appImageFile}.7z" "${appImageFile}"
+            7z -v1g a "${{ matrix.appimage_7z_name }}.7z" "${appImageFile}"
 
             # Output splitted archive name<TAB>size<TAB>hash list to myartifact.7z.txt
-            ls "${appImageFile}.7z".* > archives_name.txt
-            stat --printf="%s\n" "${appImageFile}.7z".* > archives_size.txt
-            md5sum "${appImageFile}.7z".* | awk '{print $1}' | tr a-z A-Z > archives_hash.txt
+            ls "${{ matrix.appimage_7z_name }}.7z".* > archives_name.txt
+            stat --printf="%s\n" "${{ matrix.appimage_7z_name }}.7z".* > archives_size.txt
+            md5sum "${{ matrix.appimage_7z_name }}.7z".* | awk '{print $1}' | tr a-z A-Z > archives_hash.txt
 
             paste -d '\t' archives_name.txt archives_size.txt archives_hash.txt > archives.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,22 +35,24 @@ jobs:
           - artifact_name: linux-noengine-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox
-            product_name: VOICEVOX
+            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: linux-noengine-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox-cpu
-            product_name: VOICEVOX-CPU
+            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: windows-noengine-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox
-            product_name: VOICEVOX
+            nsis_web_artifact_name: VOICEVOX Web Setup ${version}.${ext}
             os: windows-2019
           - artifact_name: windows-noengine-cpu-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox-cpu
-            product_name: VOICEVOX-CPU
+            nsis_web_artifact_name: VOICEVOX-CPU Web Setup ${version}.${ext}
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
@@ -64,7 +66,7 @@ jobs:
           # GPU: "name": "voicevox" => "name": "voicevox"
           # CPU: "name": "voicevox" => "name": "voicevox-cpu"
           sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
-          sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
+          # sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
 
       - name: Set output Node version
         id: node-version
@@ -128,6 +130,10 @@ jobs:
       # Build result will be exported to ${{ matrix.artifact_path }}
       - name: Build Electron
         shell: bash
+        env:
+          NSIS_WEB_ARTIFACT_NAME: ${{ env.nsis_web_artifact_name }}
+          LINUX_ARTIFACT_NAME: ${{ env.linux_artifact_name }}
+          LINUX_EXECUTABLE_NAME: ${{ env.linux_executable_name }}
         run: npm run electron:build_pnever -- --dir
 
       - name: Upload NoEngine Prepackage
@@ -355,22 +361,24 @@ jobs:
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
             package_name: voicevox-cpu
-            product_name: VOICEVOX-CPU
+            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
             package_name: voicevox
-            product_name: VOICEVOX
+            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: windows-cpu-nsis-web
             engine_artifact_name: windows-cpu-prepackage
             package_name: voicevox-cpu
-            product_name: VOICEVOX-CPU
+            nsis_web_artifact_name: VOICEVOX-CPU Web Setup ${version}.${ext}
             os: windows-2019
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
             package_name: voicevox
-            product_name: VOICEVOX
+            nsis_web_artifact_name: VOICEVOX Web Setup ${version}.${ext}
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
@@ -389,7 +397,7 @@ jobs:
           # GPU: "name": "voicevox" => "name": "voicevox"
           # CPU: "name": "voicevox" => "name": "voicevox-cpu"
           sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
-          sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
+          # sed -i 's/productName: "VOICEVOX"/productName: "${{ matrix.product_name }}"/' vue.config.js
 
       - name: Download and extract engine-prepackage artifact
         uses: actions/download-artifact@v2
@@ -455,6 +463,10 @@ jobs:
       # NOTE: prepackage can be removed before splitting nsis-web archive
       - name: Build Electron
         shell: bash
+        env:
+          NSIS_WEB_ARTIFACT_NAME: ${{ env.nsis_web_artifact_name }}
+          LINUX_ARTIFACT_NAME: ${{ env.linux_artifact_name }}
+          LINUX_EXECUTABLE_NAME: ${{ env.linux_executable_name }}
         run: npm run electron:build_pnever -- --prepackaged "prepackage/"
 
       - name: Show disk space (debug info)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -357,7 +357,7 @@ jobs:
         run: |
           # GPU: "name": "voicevox" => "name": "voicevox"
           # CPU: "name": "voicevox" => "name": "voicevox_cpu"
-          sed 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/'
+          sed -i 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/' package.json
 
       - name: Download and extract engine-prepackage artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -310,8 +310,8 @@ jobs:
         if: startsWith(matrix.artifact_name, 'linux-') # linux
         shell: bash
         run: |
-          chmod +x prepackage/${{ matrix.linux_executable_name }}
-          chmod +x prepackage/run
+          chmod +x "prepackage/${{ matrix.linux_executable_name }}"
+          chmod +x "prepackage/run"
 
       - name: Set BUILD_IDENTIFIER env var
         if: startsWith(matrix.artifact_name, 'linux-') # linux
@@ -425,8 +425,8 @@ jobs:
         if: endsWith(matrix.artifact_name, '-appimage') # linux
         shell: bash
         run: |
-          chmod +x prepackage/${{ matrix.linux_executable_name }}
-          chmod +x prepackage/run
+          chmod +x "prepackage/${{ matrix.linux_executable_name }}"
+          chmod +x "prepackage/run"
 
       - name: Show disk space (debug info)
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -348,10 +348,10 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      # If CPU/GPU build have the same package name,
-      # NSIS installer and 7z files have the duplicated names.
-      # We should have the difference package names between CPU/GPU build
-      # because the same name files cannot be uploaded to one GitHub Release.
+      # If the CPU/GPU builds have the same package name,
+      # the NSIS installer and the 7z files have duplicate names.
+      # Files with the same name cannot be uploaded to a single GitHub Release,
+      # so different package names should be used for CPU/GPU builds.
       - name: Replace package name
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -456,14 +456,14 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         artifact_name:
-          # - linux-cpu-appimage
+          - linux-cpu-appimage
           - linux-nvidia-appimage
-          # - windows-cpu-nsis-web
+          - windows-cpu-nsis-web
           - windows-nvidia-nsis-web
         include:
-          # - artifact_name: linux-cpu-appimage
+          - artifact_name: linux-cpu-appimage
           - artifact_name: linux-nvidia-appimage
-          # - artifact_name: windows-cpu-nsis-web
+          - artifact_name: windows-cpu-nsis-web
           - artifact_name: windows-nvidia-nsis-web
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,24 +35,24 @@ jobs:
           - artifact_name: linux-noengine-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox
-            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_artifact_name: 'VOICEVOX-${version}.AppImage'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: linux-noengine-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox-cpu
-            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_artifact_name: 'VOICEVOX-${version}.AppImage'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: windows-noengine-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox
-            nsis_web_artifact_name: VOICEVOX Web Setup ${version}.${ext}
+            nsis_web_artifact_name: 'VOICEVOX Web Setup ${version}.${ext}'
             os: windows-2019
           - artifact_name: windows-noengine-cpu-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox-cpu
-            nsis_web_artifact_name: VOICEVOX-CPU Web Setup ${version}.${ext}
+            nsis_web_artifact_name: 'VOICEVOX-CPU Web Setup ${version}.${ext}'
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
@@ -131,9 +131,9 @@ jobs:
       - name: Build Electron
         shell: bash
         env:
-          NSIS_WEB_ARTIFACT_NAME: ${{ env.nsis_web_artifact_name }}
-          LINUX_ARTIFACT_NAME: ${{ env.linux_artifact_name }}
-          LINUX_EXECUTABLE_NAME: ${{ env.linux_executable_name }}
+          NSIS_WEB_ARTIFACT_NAME: ${{ matrix.nsis_web_artifact_name }}
+          LINUX_ARTIFACT_NAME: ${{ matrix.linux_artifact_name }}
+          LINUX_EXECUTABLE_NAME: ${{ matrix.linux_executable_name }}
         run: npm run electron:build_pnever -- --dir
 
       - name: Upload NoEngine Prepackage
@@ -464,9 +464,9 @@ jobs:
       - name: Build Electron
         shell: bash
         env:
-          NSIS_WEB_ARTIFACT_NAME: ${{ env.nsis_web_artifact_name }}
-          LINUX_ARTIFACT_NAME: ${{ env.linux_artifact_name }}
-          LINUX_EXECUTABLE_NAME: ${{ env.linux_executable_name }}
+          NSIS_WEB_ARTIFACT_NAME: ${{ matrix.nsis_web_artifact_name }}
+          LINUX_ARTIFACT_NAME: ${{ matrix.linux_artifact_name }}
+          LINUX_EXECUTABLE_NAME: ${{ matrix.linux_executable_name }}
         run: npm run electron:build_pnever -- --prepackaged "prepackage/"
 
       - name: Show disk space (debug info)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -512,15 +512,15 @@ jobs:
       matrix:
         os: [ubuntu-18.04]
         artifact_name:
-          - linux-cpu-appimage
           - linux-nvidia-appimage
-          - windows-cpu-nsis-web
+          - linux-cpu-appimage
           - windows-nvidia-nsis-web
+          - windows-cpu-nsis-web
         include:
-          - artifact_name: linux-cpu-appimage
           - artifact_name: linux-nvidia-appimage
-          - artifact_name: windows-cpu-nsis-web
+          - artifact_name: linux-cpu-appimage
           - artifact_name: windows-nvidia-nsis-web
+          - artifact_name: windows-cpu-nsis-web
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           - artifact_name: linux-noengine-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox-cpu
-            product_name: VOICEVOX CPU
+            product_name: VOICEVOX-CPU
             os: ubuntu-18.04
           - artifact_name: windows-noengine-prepackage
             artifact_path: dist_electron/win-unpacked
@@ -50,7 +50,7 @@ jobs:
           - artifact_name: windows-noengine-cpu-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox-cpu
-            product_name: VOICEVOX CPU
+            product_name: VOICEVOX-CPU
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
@@ -355,7 +355,7 @@ jobs:
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
             package_name: voicevox-cpu
-            product_name: VOICEVOX CPU
+            product_name: VOICEVOX-CPU
             os: ubuntu-18.04
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
@@ -365,7 +365,7 @@ jobs:
           - artifact_name: windows-cpu-nsis-web
             engine_artifact_name: windows-cpu-prepackage
             package_name: voicevox-cpu
-            product_name: VOICEVOX CPU
+            product_name: VOICEVOX-CPU
             os: windows-2019
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,12 +172,12 @@ jobs:
           - artifact_name: linux-nvidia-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
-            targz_name: voicevox-nvidia
+            targz_name: VOICEVOX
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
             noengine_artifact_name: linux-noengine-cpu-prepackage
             voicevox_engine_asset_name: linux-cpu
-            targz_name: voicevox-cpu
+            targz_name: VOICEVOX-CPU
           # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-prepackage
             noengine_artifact_name: windows-noengine-prepackage
@@ -335,7 +335,7 @@ jobs:
         shell: bash
         run: |
           mv prepackage VOICEVOX
-          tar cf ${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz VOICEVOX/
+          tar cf "${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz" VOICEVOX/
 
       - name: Show disk space (debug info)
         if: startsWith(matrix.artifact_name, 'linux-') # linux
@@ -348,7 +348,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-targz
-          path: ${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz
+          path: "${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz"
 
 
   build-distributable:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,10 +172,12 @@ jobs:
           - artifact_name: linux-nvidia-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
+            targz_name: voicevox-nvidia
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
             noengine_artifact_name: linux-noengine-cpu-prepackage
             voicevox_engine_asset_name: linux-cpu
+            targz_name: voicevox-cpu
           # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-prepackage
             noengine_artifact_name: windows-noengine-prepackage
@@ -333,7 +335,7 @@ jobs:
         shell: bash
         run: |
           mv prepackage VOICEVOX
-          tar cf voicevox-${{ env.BUILD_IDENTIFIER }}.tar.gz VOICEVOX/
+          tar cf ${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz VOICEVOX/
 
       - name: Show disk space (debug info)
         if: startsWith(matrix.artifact_name, 'linux-') # linux
@@ -346,7 +348,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}-targz
-          path: voicevox-${{ env.BUILD_IDENTIFIER }}.tar.gz
+          path: ${{ matrix.targz_name }}-${{ env.BUILD_IDENTIFIER }}.tar.gz
 
 
   build-distributable:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,13 +35,13 @@ jobs:
           - artifact_name: linux-noengine-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox
-            linux_artifact_name: 'VOICEVOX-${version}.AppImage'
+            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: linux-noengine-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox-cpu
-            linux_artifact_name: 'VOICEVOX-${version}.AppImage'
+            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           - artifact_name: windows-noengine-prepackage
@@ -358,27 +358,27 @@ jobs:
           - windows-cpu-nsis-web
           - windows-nvidia-nsis-web
         include:
-          - artifact_name: linux-cpu-appimage
-            engine_artifact_name: linux-cpu-prepackage
-            package_name: voicevox-cpu
-            linux_artifact_name: VOICEVOX-${version}.AppImage
-            linux_executable_name: voicevox
-            os: ubuntu-18.04
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
             package_name: voicevox
-            linux_artifact_name: VOICEVOX-${version}.AppImage
+            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
-          - artifact_name: windows-cpu-nsis-web
-            engine_artifact_name: windows-cpu-prepackage
+          - artifact_name: linux-cpu-appimage
+            engine_artifact_name: linux-cpu-prepackage
             package_name: voicevox-cpu
-            nsis_web_artifact_name: VOICEVOX-CPU Web Setup ${version}.${ext}
-            os: windows-2019
+            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
+            linux_executable_name: voicevox
+            os: ubuntu-18.04
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
             package_name: voicevox
-            nsis_web_artifact_name: VOICEVOX Web Setup ${version}.${ext}
+            nsis_web_artifact_name: 'VOICEVOX Web Setup ${version}.${ext}'
+            os: windows-2019
+          - artifact_name: windows-cpu-nsis-web
+            engine_artifact_name: windows-cpu-prepackage
+            package_name: voicevox-cpu
+            nsis_web_artifact_name: 'VOICEVOX-CPU Web Setup ${version}.${ext}'
             os: windows-2019
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,11 +172,13 @@ jobs:
           - artifact_name: linux-nvidia-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
+            linux_executable_name: voicevox
             targz_name: VOICEVOX
           # Linux CPU
           - artifact_name: linux-cpu-prepackage
             noengine_artifact_name: linux-noengine-cpu-prepackage
             voicevox_engine_asset_name: linux-cpu
+            linux_executable_name: voicevox
             targz_name: VOICEVOX-CPU
           # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-prepackage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,11 +136,9 @@ jobs:
           - artifact_name: linux-cpu-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-cpu
-            os: ubuntu-18.04
           - artifact_name: linux-nvidia-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
-            os: ubuntu-18.04
           - artifact_name: windows-cpu-prepackage
             noengine_artifact_name: windows-noengine-prepackage
             voicevox_engine_asset_name: windows-cpu
@@ -324,27 +322,42 @@ jobs:
       fail-fast: false
       matrix:
         artifact_name:
-          # - linux-cpu-appimage
+          - linux-cpu-appimage
           - linux-nvidia-appimage
-          # - windows-cpu-nsis-web
+          - windows-cpu-nsis-web
           - windows-nvidia-nsis-web
         include:
-          # - artifact_name: linux-cpu-appimage
-          #   engine_artifact_name: linux-cpu-prepackage
-          #   os: ubuntu-18.04
+          - artifact_name: linux-cpu-appimage
+            engine_artifact_name: linux-cpu-prepackage
+            package_name: voicevox_cpu
+            os: ubuntu-18.04
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
+            package_name: voicevox
             os: ubuntu-18.04
-          # - artifact_name: windows-cpu-nsis-web
-          #   engine_artifact_name: windows-cpu-prepackage
-          #   os: windows-2019
+          - artifact_name: windows-cpu-nsis-web
+            engine_artifact_name: windows-cpu-prepackage
+            package_name: voicevox_cpu
+            os: windows-2019
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
+            package_name: voicevox
             os: windows-2019
 
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@master
+
+      # If CPU/GPU build have the same package name,
+      # NSIS installer and 7z files have the duplicated names.
+      # We should have the difference package names between CPU/GPU build
+      # because the same name files cannot be uploaded to one GitHub Release.
+      - name: Replace package name
+        shell: bash
+        run: |
+          # GPU: "name": "voicevox" => "name": "voicevox"
+          # CPU: "name": "voicevox" => "name": "voicevox_cpu"
+          sed 's/"name": "voicevox"/"name": "${{ matrix.package_name }}"/'
 
       - name: Download and extract engine-prepackage artifact
         uses: actions/download-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,14 @@ jobs:
           - artifact_name: linux-noengine-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox
-            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
+            linux_artifact_name: 'VOICEVOX.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           # Linux CPU
           - artifact_name: linux-noengine-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox-cpu
-            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
+            linux_artifact_name: 'VOICEVOX.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           # Windows NVIDIA GPU
@@ -370,14 +370,14 @@ jobs:
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
             package_name: voicevox
-            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
+            linux_artifact_name: 'VOICEVOX.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           # Linux CPU
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
             package_name: voicevox-cpu
-            linux_artifact_name: 'VOICEVOX-${version}.${ext}'
+            linux_artifact_name: 'VOICEVOX.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
           # Windows NVIDIA GPU

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,23 +32,27 @@ jobs:
           - windows-noengine-prepackage
           - windows-noengine-cpu-prepackage
         include:
+          # Linux NVIDIA GPU
           - artifact_name: linux-noengine-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox
             linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
+          # Linux CPU
           - artifact_name: linux-noengine-cpu-prepackage
             artifact_path: dist_electron/linux-unpacked
             package_name: voicevox-cpu
             linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
+          # Windows NVIDIA GPU
           - artifact_name: windows-noengine-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox
             nsis_web_artifact_name: 'VOICEVOX Web Setup ${version}.${ext}'
             os: windows-2019
+          # Windows CPU
           - artifact_name: windows-noengine-cpu-prepackage
             artifact_path: dist_electron/win-unpacked
             package_name: voicevox-cpu
@@ -159,23 +163,27 @@ jobs:
         #   - ${{ env.VOICEVOX_ENGINE_VERSION }}
         os: [ubuntu-18.04]
         artifact_name:
-          - linux-cpu-prepackage
           - linux-nvidia-prepackage
-          - windows-cpu-prepackage
+          - linux-cpu-prepackage
           - windows-nvidia-prepackage
+          - windows-cpu-prepackage
         include:
-          - artifact_name: linux-cpu-prepackage
-            noengine_artifact_name: linux-noengine-cpu-prepackage
-            voicevox_engine_asset_name: linux-cpu
+          # Linux NVIDIA GPU
           - artifact_name: linux-nvidia-prepackage
             noengine_artifact_name: linux-noengine-prepackage
             voicevox_engine_asset_name: linux-nvidia
-          - artifact_name: windows-cpu-prepackage
-            noengine_artifact_name: windows-noengine-cpu-prepackage
-            voicevox_engine_asset_name: windows-cpu
+          # Linux CPU
+          - artifact_name: linux-cpu-prepackage
+            noengine_artifact_name: linux-noengine-cpu-prepackage
+            voicevox_engine_asset_name: linux-cpu
+          # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-prepackage
             noengine_artifact_name: windows-noengine-prepackage
             voicevox_engine_asset_name: windows-nvidia
+          # Windows CPU
+          - artifact_name: windows-cpu-prepackage
+            noengine_artifact_name: windows-noengine-cpu-prepackage
+            voicevox_engine_asset_name: windows-cpu
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -353,28 +361,32 @@ jobs:
       fail-fast: false
       matrix:
         artifact_name:
-          - linux-cpu-appimage
           - linux-nvidia-appimage
-          - windows-cpu-nsis-web
+          - linux-cpu-appimage
           - windows-nvidia-nsis-web
+          - windows-cpu-nsis-web
         include:
+          # Linux NVIDIA GPU
           - artifact_name: linux-nvidia-appimage
             engine_artifact_name: linux-nvidia-prepackage
             package_name: voicevox
             linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
+          # Linux CPU
           - artifact_name: linux-cpu-appimage
             engine_artifact_name: linux-cpu-prepackage
             package_name: voicevox-cpu
             linux_artifact_name: 'VOICEVOX-${version}.${ext}'
             linux_executable_name: voicevox
             os: ubuntu-18.04
+          # Windows NVIDIA GPU
           - artifact_name: windows-nvidia-nsis-web
             engine_artifact_name: windows-nvidia-prepackage
             package_name: voicevox
             nsis_web_artifact_name: 'VOICEVOX Web Setup ${version}.${ext}'
             os: windows-2019
+          # Windows CPU
           - artifact_name: windows-cpu-nsis-web
             engine_artifact_name: windows-cpu-prepackage
             package_name: voicevox-cpu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -498,14 +498,21 @@ jobs:
           path: |
             dist_electron/*.AppImage
 
+      - name: Create Windows NSIS Web artifact directory
+        if: endsWith(matrix.artifact_name, '-nsis-web')
+        shell: bash
+        run: |
+          mkdir -p nsis-web-artifact
+          mv dist_electron/nsis-web/out/*.7z.* nsis-web-artifact/
+          mv dist_electron/nsis-web/*.exe nsis-web-artifact/
+
       - name: Upload Windows NSIS Web artifact
         if: endsWith(matrix.artifact_name, '-nsis-web')
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.artifact_name }}
           path: |
-            dist_electron/nsis-web/out/*.7z.*
-            dist_electron/nsis-web/*.exe
+            nsis-web-artifact/*
 
 
   upload-distributable-to-release:

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -232,9 +232,9 @@ echo "Extacting desktop entry"
 APPIMAGE=$(7z l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
 chmod +x "${APPIMAGE}"
 
-./${APPIMAGE} --appimage-extract '*.desktop'
-./${APPIMAGE} --appimage-extract 'usr/share/icons/**'
-./${APPIMAGE} --appimage-extract '*.png' # symbolic link to icon
+"./${APPIMAGE}" --appimage-extract '*.desktop'
+"./${APPIMAGE}" --appimage-extract 'usr/share/icons/**'
+"./${APPIMAGE}" --appimage-extract '*.png' # symbolic link to icon
 
 # Install desktop entry
 echo "Installing desktop entry"

--- a/build/installer_linux.sh
+++ b/build/installer_linux.sh
@@ -229,7 +229,7 @@ rm -f "list.txt"
 # Extract desktop entry
 echo "Extacting desktop entry"
 
-APPIMAGE=$(echo "${FIRST_ARCHIVE}" | sed 's/\(.*.AppImage\).*/\1/')
+APPIMAGE=$(7z l -slt -ba "${FIRST_ARCHIVE}" | grep 'Path = ' | head -n1 | sed 's/Path = \(.*\)/\1/')
 chmod +x "${APPIMAGE}"
 
 ./${APPIMAGE} --appimage-extract '*.desktop'

--- a/build/splitNsisArchive.js
+++ b/build/splitNsisArchive.js
@@ -12,6 +12,12 @@ const createIni = (sizes, hashes) => {
 
 // target: electron-builder.Target
 exports.default = async function (target) {
+  const projectName = process.env.npm_package_name;
+  if (projectName === undefined) {
+    const ErrorMessage = "Project name is undefined.";
+    console.error(ErrorMessage);
+    throw ErrorMessage;
+  }
   const projectVersion = process.env.npm_package_version;
   if (projectVersion === undefined) {
     const ErrorMessage = "Project version is undefined.";
@@ -19,7 +25,7 @@ exports.default = async function (target) {
     throw ErrorMessage;
   }
   const segmentSize = 1 * 1024 ** 3; // 1GB
-  const fileName = `voicevox-${projectVersion}-x64.nsis.7z`; // target file name
+  const fileName = `${projectName}-${projectVersion}-x64.nsis.7z`; // target file name
   const targetDirectory = target.outDir; // for nsis-web
   const outputDirectory = path.resolve(targetDirectory, "out");
   const inputFile = path.resolve(targetDirectory, fileName);

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,6 +6,17 @@ const process = require("process");
 const VOICEVOX_ENGINE_DIR =
   process.env.VOICEVOX_ENGINE_DIR ?? "../voicevox_engine/run.dist/";
 
+// ${productName} Web Setup ${version}.${ext}
+const NSIS_WEB_ARTIFACT_NAME =
+  process.env.NSIS_WEB_ARTIFACT_NAME;
+
+// ${productName}-${version}.AppImage
+const LINUX_ARTIFACT_NAME =
+  process.env.LINUX_ARTIFACT_NAME;
+
+const LINUX_EXECUTABLE_NAME =
+  process.env.LINUX_EXECUTABLE_NAME;
+
 module.exports = {
   configureWebpack: {
     devtool: "source-map",
@@ -50,6 +61,7 @@ module.exports = {
           buildResources: "build",
         },
         nsisWeb: {
+          artifactName: NSIS_WEB_ARTIFACT_NAME,
           include: "build/installer.nsh",
           oneClick: false,
           allowToChangeInstallationDirectory: true,
@@ -60,6 +72,8 @@ module.exports = {
           vPrefixedTagName: false,
         },
         linux: {
+          artifactName: LINUX_ARTIFACT_NAME,
+          executableName: LINUX_EXECUTABLE_NAME,
           icon: "public/icon.png",
           category: "AudioVideo",
           target: [

--- a/vue.config.js
+++ b/vue.config.js
@@ -9,7 +9,7 @@ const VOICEVOX_ENGINE_DIR =
 // ${productName} Web Setup ${version}.${ext}
 const NSIS_WEB_ARTIFACT_NAME = process.env.NSIS_WEB_ARTIFACT_NAME;
 
-// ${productName}-${version}.AppImage
+// ${productName}-${version}.${ext}
 const LINUX_ARTIFACT_NAME = process.env.LINUX_ARTIFACT_NAME;
 
 // ${packageName}

--- a/vue.config.js
+++ b/vue.config.js
@@ -12,6 +12,7 @@ const NSIS_WEB_ARTIFACT_NAME = process.env.NSIS_WEB_ARTIFACT_NAME;
 // ${productName}-${version}.AppImage
 const LINUX_ARTIFACT_NAME = process.env.LINUX_ARTIFACT_NAME;
 
+// ${packageName}
 const LINUX_EXECUTABLE_NAME = process.env.LINUX_EXECUTABLE_NAME;
 
 module.exports = {

--- a/vue.config.js
+++ b/vue.config.js
@@ -7,15 +7,12 @@ const VOICEVOX_ENGINE_DIR =
   process.env.VOICEVOX_ENGINE_DIR ?? "../voicevox_engine/run.dist/";
 
 // ${productName} Web Setup ${version}.${ext}
-const NSIS_WEB_ARTIFACT_NAME =
-  process.env.NSIS_WEB_ARTIFACT_NAME;
+const NSIS_WEB_ARTIFACT_NAME = process.env.NSIS_WEB_ARTIFACT_NAME;
 
 // ${productName}-${version}.AppImage
-const LINUX_ARTIFACT_NAME =
-  process.env.LINUX_ARTIFACT_NAME;
+const LINUX_ARTIFACT_NAME = process.env.LINUX_ARTIFACT_NAME;
 
-const LINUX_EXECUTABLE_NAME =
-  process.env.LINUX_EXECUTABLE_NAME;
+const LINUX_EXECUTABLE_NAME = process.env.LINUX_EXECUTABLE_NAME;
 
 module.exports = {
   configureWebpack: {
@@ -61,7 +58,8 @@ module.exports = {
           buildResources: "build",
         },
         nsisWeb: {
-          artifactName: NSIS_WEB_ARTIFACT_NAME,
+          artifactName:
+            NSIS_WEB_ARTIFACT_NAME !== "" ? NSIS_WEB_ARTIFACT_NAME : undefined,
           include: "build/installer.nsh",
           oneClick: false,
           allowToChangeInstallationDirectory: true,
@@ -72,8 +70,10 @@ module.exports = {
           vPrefixedTagName: false,
         },
         linux: {
-          artifactName: LINUX_ARTIFACT_NAME,
-          executableName: LINUX_EXECUTABLE_NAME,
+          artifactName:
+            LINUX_ARTIFACT_NAME !== "" ? LINUX_ARTIFACT_NAME : undefined,
+          executableName:
+            LINUX_EXECUTABLE_NAME !== "" ? LINUX_EXECUTABLE_NAME : undefined,
           icon: "public/icon.png",
           category: "AudioVideo",
           target: [


### PR DESCRIPTION
## 内容

Windows・Linux用のCPU版自動ビルドを有効化します。

#264 では、GitHub Releaseにアップロードするインストーラ・分割7zのファイル名が重複する問題 https://github.com/Hiroshiba/voicevox/pull/264#issuecomment-927196258 が起き、対応を考えるため、CPU版対応はいったんコメントアウトして、別PR（このPR）にしました。

ファイル名重複の回避方法としては、以下のような候補を考えました。

1. `package.json`の`name`（`packageName`）、`vue.config.js`の`productName`の一時的な書き換え（このPRで採用している方法）
2. NSISインストーラ・分割7zをビルド後にファイル名変更し、`installer.nsh`で分割7zのダウンロードURLを書き換え
3. VOICEVOXはデバイス別リリースしない（ENGINEやCOREを別々にダウンロード）

このPRでは暫定的に、ほぼCIだけで簡単に対応できる1を採用しています。

ビルドの段階によって、`packageName`・`productName`が変わるのを防ぐため、VOICEVOX ENGINEが含まれないArtifactについて、CPU版とGPU版をそれぞれ作成するように変更しました。

`productName`内でスペースではなくハイフンを使用しているのは、GitHub Releaseにアップロードしたときにスペースがピリオドに置き換えられて名前の不一致が起こる可能性があること、シェルスクリプト上での扱いが不便なことが理由です。


## 議論：VOICEVOX・ENGINE・COREのインストール方法

将来的には、回避方法3を実装するのが理想的なのかなと思っています。

いまのところ優先度が低いと思うのでメモとしてですが、実現には以下のような候補を考えました。
https://github.com/Hiroshiba/voicevox/issues/298, https://github.com/Hiroshiba/voicevox_core/issues/16 で、ENGINEがCOREの対応デバイスを認識して変更できるようになるとして、インストール方法3くらいがいいのかなと思っています（配布物のURLは別々でもインストーラは1つかもしれない）。

1. インストーラでCPU版・GPU版どちらをダウンロードするか選択（できるかわからない）
2. VOICEVOXとENGINEの配布物を分離（別々にダウンロードする。インストーラが1つの場合、1と同じ）
    - VOICEVOX（いまのnoengineビルド）
    - CORE（四国めたん、ずんだもん）を含むENGINE
3. VOICEVOX・ENGINEとCOREの配布物を分離
    - VOICEVOX・COREの含まれないENGINE（同梱）
    - CORE（四国めたん、ずんだもん）
4. VOICEVOXとENGINEとCOREの配布物を分離（ #220 でローカルエンジンをインストールしない場合を想定）
    - VOICEVOX（いまのnoengineビルド）
    - COREの含まれないENGINE
    - CORE（四国めたん、ずんだもん）

## 関連 Issue

ref https://github.com/Hiroshiba/voicevox/pull/264#issuecomment-927196258
ref https://github.com/Hiroshiba/voicevox/issues/218#issuecomment-933569505

## Artifactの種類
### 全Artifactリスト

<details>

- linux-cpu-appimage
- linux-cpu-appimage-release
- linux-cpu-prepackage
- linux-cpu-prepackage-targz
- linux-noengine-cpu-prepackage
- linux-noengine-prepackage
- linux-nvidia-appimage
- linux-nvidia-appimage-release
- linux-nvidia-prepackage
- linux-nvidia-prepackage-targz
- windows-cpu-nsis-web
- windows-cpu-prepackage
- windows-noengine-cpu-prepackage
- windows-noengine-prepackage
- windows-nvidia-nsis-web
- windows-nvidia-prepackage

</details>

### ReleaseにアップロードするArtifact

- linux-nvidia-appimage-release（GPU版Linux AppImageインストーラ用）
- linux-cpu-appimage-release（CPU版Linux AppImageインストーラ用）
- windows-nvidia-nsis-web（GPU版Windows NSISインストーラ用）
- windows-cpu-nsis-web（CPU版Windows NSISインストーラ用）

展開して、中のファイルをすべてReleaseにアップロード

```shell
gh release upload --repo=Hiroshiba/voicevox 0.x.x *
```

### Google DriveにアップロードするArtifact

- linux-nvidia-appimage（GPU版Linux AppImage）
- linux-cpu-appimage（CPU版Linux AppImage）
- windows-nvidia-prepackage（GPU版Windows zip配布）
- windows-cpu-prepackage（CPU版Windows zip配布）

#### オプション

- linux-nvidia-prepackage-targz（GPU版Linux tar.gz配布）
- linux-cpu-prepackage-targz（CPU版Linux tar.gz配布）


## Linux AppImageインストーラ

```shell
# GPU版
NAME=linux-nvidia-appimage VERSION=0.x.x curl -fsSL https://raw.githubusercontent.com/Hiroshiba/voicevox/main/build/installer_linux.sh | bash

# CPU版
NAME=linux-cpu-appimage VERSION=0.x.x curl -fsSL https://raw.githubusercontent.com/Hiroshiba/voicevox/main/build/installer_linux.sh | bash
```
