### PR TITLE
REMOVE_ALL_AUDIO_ITEMのoldCommandの削除

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1,6 +1,5 @@
 import { AudioQuery, AccentPhrase, Configuration, DefaultApi } from "@/openapi";
 import path from "path";
-import { oldCreateCommandAction } from "./command";
 import { v4 as uuidv4 } from "uuid";
 import {
   AudioItem,
@@ -333,13 +332,11 @@ export const audioStore: VoiceVoxStoreOptions<
 
       commit("SET_CHARACTER_INFOS", { characterInfos });
     }),
-    REMOVE_ALL_AUDIO_ITEM: oldCreateCommandAction((draft) => {
-      for (const audioKey of draft.audioKeys) {
-        delete draft.audioItems[audioKey];
-        delete draft.audioStates[audioKey];
+    REMOVE_ALL_AUDIO_ITEM({ commit, state }) {
+      for (const audioKey of [...state.audioKeys]) {
+        commit("REMOVE_AUDIO_ITEM", { audioKey });
       }
-      draft.audioKeys.splice(0, draft.audioKeys.length);
-    }),
+    },
     async GENERATE_AUDIO_ITEM(
       { getters, dispatch },
       payload: { text?: string; speaker?: number }

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -7,11 +7,7 @@ import {
 } from "./vuex";
 import { Operation } from "rfc6902";
 import { AccentPhrase, AudioQuery } from "@/openapi";
-import {
-  createCommandMutationTree,
-  PayloadRecipeTree,
-  OldCommand,
-} from "./command";
+import { createCommandMutationTree, PayloadRecipeTree } from "./command";
 import {
   CharacterInfo,
   Encoding as EncodingType,
@@ -347,7 +343,6 @@ export type CommandGetters = {
 };
 
 export type CommandMutations = {
-  OLD_PUSH_COMMAND: { command: OldCommand<State> };
   UNDO: undefined;
   REDO: undefined;
   CLEAR_COMMANDS: undefined;


### PR DESCRIPTION
## 内容

project.tsで使われていた`REMOVE_ALL_AUDIO_ITEM`アクションを`oldCreateCommandAction`を用いずにmutationを叩くように変更しました。また、それに伴い不要となったoldCommandを削除しました。

## 関連 Issue

ref #116

## スクリーンショット・動画など

## その他
