### PR TITLE
保存先を選んでから音声の生成を行う

### DIFF
--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -546,11 +546,12 @@ export const audioStore: VoiceVoxStoreOptions<
           }
         }
 
-        const blob = await dispatch("GENERATE_AUDIO", {
-          audioKey,
-        });
+        let blob = await dispatch("GET_AUDIO_CACHE", { audioKey });
         if (!blob) {
-          return { result: "ENGINE_ERROR", path: filePath };
+          blob = await dispatch("GENERATE_AUDIO", { audioKey });
+          if (!blob) {
+            return { result: "ENGINE_ERROR", path: filePath };
+          }
         }
 
         try {

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -521,10 +521,6 @@ export const audioStore: VoiceVoxStoreOptions<
           encoding?: EncodingType;
         }
       ): Promise<SaveResultObject> => {
-        const blobPromise = dispatch("GENERATE_AUDIO", {
-          audioKey,
-        });
-
         if (state.savingSetting.fixedExportEnabled) {
           filePath = path.join(
             state.savingSetting.fixedExportDir,
@@ -550,7 +546,9 @@ export const audioStore: VoiceVoxStoreOptions<
           }
         }
 
-        const blob = await blobPromise;
+        const blob = await dispatch("GENERATE_AUDIO", {
+          audioKey,
+        });
         if (!blob) {
           return { result: "ENGINE_ERROR", path: filePath };
         }


### PR DESCRIPTION
## 内容

以前 https://github.com/Hiroshiba/voicevox/pull/62 にて、音声の保存先を選択するダイアログを表示している裏で、
音声の生成も同時に進めておくような変更を行いました。
これにより、通常の保存時には体感上の待ち時間を少しだけ減らしていました。

しかし保存をキャンセルした場合にも保存が進行してしており( https://github.com/Hiroshiba/voicevox/issues/190 )、
現状これを中断する方法がなく、少なくとも短期的には解決が難しい状況です。

現在は CPU 版においても保存処理が速くなったため、
相対的に見てこの処理はメリットよりもデメリットが大きくなっていると感じます。
そこで、保存先を選択してから音声の生成を行うようにすることで、キャンセル時の問題を解決します。

## 関連 Issue

close #190

※エンジン側での音声生成中断のニーズは依然としてあるはずなので、https://github.com/Hiroshiba/voicevox_engine/issues/64 は残しておきます。
