### PR TITLE
ヘルプ画面のヘッダー等更新

### DIFF
--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -7,7 +7,7 @@
     class="help-dialog"
     v-model="modelValueComputed"
   >
-    <q-layout container view="lHh Lpr lff" class="bg-white">
+    <q-layout container view="hHh Lpr lff" class="bg-white">
       <q-drawer
         bordered
         show-if-above
@@ -29,15 +29,6 @@
               <q-item-section>{{ page.name }}</q-item-section>
             </q-item>
           </q-list>
-          <q-space />
-          <q-list>
-            <q-item clickable v-ripple @click="modelValueComputed = false">
-              <q-item-section side>
-                <q-icon name="keyboard_arrow_left" />
-              </q-item-section>
-              <q-item-section>ヘルプを閉じる</q-item-section>
-            </q-item>
-          </q-list>
         </div>
       </q-drawer>
 
@@ -50,7 +41,24 @@
               :name="page.name"
               class="q-pa-none"
             >
-              <component :is="page.component" />
+              <div class="root">
+                <q-header class="q-pa-sm">
+                  <q-toolbar>
+                    <q-toolbar-title class="text-secondary">
+                      ヘルプ / {{ page.name }}
+                    </q-toolbar-title>
+                    <q-space />
+                    <!-- close button -->
+                    <q-btn
+                      round
+                      flat
+                      icon="close"
+                      @click="modelValueComputed = false"
+                    />
+                  </q-toolbar>
+                </q-header>
+                <component :is="page.component" />
+              </div>
             </q-tab-panel>
           </q-tab-panels>
         </q-page>

--- a/src/components/HowToUse.vue
+++ b/src/components/HowToUse.vue
@@ -1,14 +1,7 @@
 <template>
-  <div class="root">
-    <q-header class="q-py-sm">
-      <q-toolbar>
-        <q-toolbar-title class="text-secondary">使い方</q-toolbar-title>
-      </q-toolbar>
-    </q-header>
-    <q-page class="relarive-absolute-wrapper scroller">
-      <div class="q-pa-md markdown markdown-body" v-html="howToUse"></div>
-    </q-page>
-  </div>
+  <q-page class="relarive-absolute-wrapper scroller">
+    <div class="q-pa-md markdown markdown-body" v-html="howToUse"></div>
+  </q-page>
 </template>
 
 <script lang="ts">

--- a/src/components/LibraryPolicy.vue
+++ b/src/components/LibraryPolicy.vue
@@ -1,44 +1,35 @@
 <template>
-  <div class="root">
-    <q-header class="q-py-sm">
-      <q-toolbar>
-        <q-btn
-          unelevated
-          label="戻る"
-          color="white"
-          text-color="secondary"
-          :disable="detailIndex === undefined"
-          @click="selectCharacterInfIndex(undefined)"
-        />
-        <q-toolbar-title class="text-secondary">{{
-          detailIndex === undefined
-            ? "音声ライブラリの利用規約"
-            : characterInfos[detailIndex].metas.speakerName
-        }}</q-toolbar-title>
-      </q-toolbar>
-    </q-header>
-    <q-page ref="scroller" class="relarive-absolute-wrapper scroller">
-      <div class="q-pa-md">
-        <q-list v-if="detailIndex === undefined">
-          <template
-            v-for="(characterInfo, index) in characterInfos"
-            :key="index"
-          >
-            <q-item clickable @click="selectCharacterInfIndex(index)">
-              <q-item-section>{{
-                characterInfo.metas.speakerName
-              }}</q-item-section>
-            </q-item>
-          </template>
-        </q-list>
+  <q-page ref="scroller" class="relarive-absolute-wrapper scroller">
+    <div class="q-pa-md">
+      <q-list v-if="detailIndex === undefined">
+        <template v-for="(characterInfo, index) in characterInfos" :key="index">
+          <q-item clickable @click="selectCharacterInfIndex(index)">
+            <q-item-section>{{
+              characterInfo.metas.speakerName
+            }}</q-item-section>
+          </q-item>
+        </template>
+      </q-list>
+      <div v-else>
+        <div class="q-mb-md">
+          <q-btn
+            outline
+            style="color: #a5d4ad"
+            icon="keyboard_arrow_left"
+            label="前画面に戻る"
+            @click="selectCharacterInfIndex(undefined)"
+          />
+        </div>
+        <div class="text-subtitle">
+          {{ characterInfos[detailIndex].metas.speakerName }}
+        </div>
         <div
-          v-else
           class="markdown"
           v-html="convertMarkdown(characterInfos[detailIndex].metas.policy)"
         ></div>
       </div>
-    </q-page>
-  </div>
+    </div>
+  </q-page>
 </template>
 
 <script lang="ts">

--- a/src/components/OssLicense.vue
+++ b/src/components/OssLicense.vue
@@ -1,43 +1,34 @@
 <template>
-  <div class="root">
-    <q-header class="q-py-sm">
-      <q-toolbar>
-        <q-btn
-          unelevated
-          label="戻る"
-          color="white"
-          text-color="secondary"
-          :disable="detailIndex === undefined"
-          @click="selectLicenseIndex(undefined)"
-        />
-        <q-toolbar-title class="text-secondary">{{
-          detailIndex === undefined
-            ? "OSSライセンス情報"
-            : licenses[detailIndex].name
-        }}</q-toolbar-title>
-      </q-toolbar>
-    </q-header>
-    <q-page ref="scroller" class="relarive-absolute-wrapper scroller">
-      <div class="q-pa-md">
-        <q-list v-if="detailIndex === undefined">
-          <q-item
-            v-for="(license, index) in licenses"
-            :key="index"
-            clickable
-            dense
-            @click="selectLicenseIndex(index)"
-          >
-            <q-item-section>{{
-              license.name + (license.version ? " | " + license.version : "")
-            }}</q-item-section>
-          </q-item>
-        </q-list>
-        <div v-else>
-          <pre>{{ licenses[detailIndex].text }}</pre>
+  <q-page ref="scroller" class="relarive-absolute-wrapper scroller">
+    <div class="q-pa-md">
+      <q-list v-if="detailIndex === undefined">
+        <q-item
+          v-for="(license, index) in licenses"
+          :key="index"
+          clickable
+          dense
+          @click="selectLicenseIndex(index)"
+        >
+          <q-item-section>{{
+            license.name + (license.version ? " | " + license.version : "")
+          }}</q-item-section>
+        </q-item>
+      </q-list>
+      <div v-else>
+        <div class="q-mb-md">
+          <q-btn
+            outline
+            style="color: #a5d4ad"
+            icon="keyboard_arrow_left"
+            label="前画面に戻る"
+            @click="selectLicenseIndex(undefined)"
+          />
         </div>
+        <div class="text-subtitle">{{ licenses[detailIndex].name }}</div>
+        <pre>{{ licenses[detailIndex].text }}</pre>
       </div>
-    </q-page>
-  </div>
+    </div>
+  </q-page>
 </template>
 
 <script lang="ts">

--- a/src/components/Policy.vue
+++ b/src/components/Policy.vue
@@ -1,16 +1,7 @@
 <template>
-  <div class="root">
-    <q-header class="q-py-sm">
-      <q-toolbar>
-        <q-toolbar-title class="text-secondary"
-          >ソフトウェアの利用規約</q-toolbar-title
-        >
-      </q-toolbar>
-    </q-header>
-    <q-page class="relarive-absolute-wrapper scroller">
-      <div class="q-pa-md markdown" v-html="policy"></div>
-    </q-page>
-  </div>
+  <q-page class="relarive-absolute-wrapper scroller">
+    <div class="q-pa-md markdown" v-html="policy"></div>
+  </q-page>
 </template>
 
 <script lang="ts">

--- a/src/components/UpdateInfo.vue
+++ b/src/components/UpdateInfo.vue
@@ -1,18 +1,9 @@
 <template>
-  <div class="root">
-    <q-header class="q-py-sm">
-      <q-toolbar>
-        <q-toolbar-title class="text-secondary"
-          >アップデート情報</q-toolbar-title
-        >
-      </q-toolbar>
-    </q-header>
-    <q-page ref="scroller" class="relarive-absolute-wrapper scroller">
-      <div class="q-pa-md">
-        <div v-html="html"></div>
-      </div>
-    </q-page>
-  </div>
+  <q-page ref="scroller" class="relarive-absolute-wrapper scroller">
+    <div class="q-pa-md">
+      <div v-html="html"></div>
+    </div>
+  </q-page>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## 内容
ヘルプ画面のヘッダーを設定画面と同じものにします。

## 関連 Issue
close #352 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
![image](https://user-images.githubusercontent.com/44311840/137618331-80933e18-49ed-4b74-87ce-af0895dc8ab6.png)

<!--

UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
ヘッダーをHelpDialog.vueに持ってきています。
前までは「音声ライブラリの利用規約」と「OSSライセンス情報」の詳細画面ではヘッダーに名前が表示されていましたが、本文中に表示されるように変更されています。