### PR TITLE
Bugfix: アクセントスライダーのシフトキーによるスクロール無効化

### DIFF
--- a/src/components/AudioAccent.vue
+++ b/src/components/AudioAccent.vue
@@ -85,6 +85,7 @@ export default defineComponent({
       onChange: changeAccent,
       modelValue: () => props.accentPhrase.accent,
       disable: () => props.uiLocked,
+      disableScroll: () => props.shiftKeyFlag,
       max: () => props.accentPhrase.moras.length,
       min: () => 1,
       step: () => 1,


### PR DESCRIPTION
## 内容

#368 の変更で設定漏れがあったので修正です．シフトキーを押した際にアクセントのスライダーがスクロールの挙動を吸わずに，画面スクロールをするようにします．

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
