### PR TITLE
macOS上での最大化・最小化・閉じるボタンの挙動や外観の調整

### DIFF
--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -43,7 +43,7 @@
       icon="lens"
       color="green"
       class="title-bar-buttons"
-      @click="minimizeWindow()"
+      @click="maximizeWindow()"
     ></q-btn>
     <q-btn
       dense
@@ -52,7 +52,7 @@
       icon="lens"
       color="yellow"
       class="title-bar-buttons"
-      @click="maximizeWindow()"
+      @click="minimizeWindow()"
     ></q-btn>
     <q-btn
       dense

--- a/src/components/TitleBarButtons.vue
+++ b/src/components/TitleBarButtons.vue
@@ -41,6 +41,7 @@
       flat
       round
       icon="lens"
+      size="8.5px"
       color="green"
       class="title-bar-buttons"
       @click="maximizeWindow()"
@@ -50,6 +51,7 @@
       flat
       round
       icon="lens"
+      size="8.5px"
       color="yellow"
       class="title-bar-buttons"
       @click="minimizeWindow()"
@@ -58,6 +60,7 @@
       dense
       flat
       icon="lens"
+      size="8.5px"
       color="red"
       class="title-bar-buttons"
       @click="closeWindow()"


### PR DESCRIPTION
## 内容

macOS において最大化ボタンと最小化ボタンの挙動が逆になっていた問題を修正しました。
また、以下の Quasar のドキュメントを参考にボタンのサイズを調整しました。
https://quasar.dev/vue-components/bar#styling

## 関連 Issue

close #427 

## スクリーンショット・動画など

https://user-images.githubusercontent.com/41382894/139923390-a7db5190-4636-4ed7-aef9-7793ddffe08b.mov

## その他


