### PR TITLE
立ち絵の表示を調整

### DIFF
--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -1,10 +1,7 @@
 <template>
-  <div class="full-width full-height">
+  <div class="character-portrait-wrapper">
     <span class="character-name">{{ characterName }}</span>
-    <img
-      :src="portraitPath"
-      class="full-width full-height character-portrait"
-    />
+    <img :src="portraitPath" class="character-portrait" />
   </div>
 </template>
 
@@ -69,8 +66,17 @@ export default defineComponent({
   );
 }
 
-.character-portrait {
-  object-fit: none;
-  object-position: center top;
+.character-portrait-wrapper {
+  display: grid;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  .character-portrait {
+    object-fit: none;
+    object-position: center top;
+    width: 100%;
+    height: fit-content;
+  }
 }
 </style>

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -71,10 +71,10 @@
         :width="$q.screen.width / 3"
         :breakpoint="0"
       >
-        <div class="column full-height">
+        <div class="character-portrait-wrapper">
           <img
             :src="characterInfos[pageIndex].portraitPath"
-            class="full-width full-height character-portrait"
+            class="character-portrait"
           />
         </div>
       </q-drawer>
@@ -268,9 +268,18 @@ export default defineComponent({
 .q-toolbar div:first-child {
   min-width: 0;
 }
-.character-portrait {
-  object-fit: none;
-  object-position: center top;
+.character-portrait-wrapper {
+  display: grid;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  .character-portrait {
+    object-fit: none;
+    object-position: center top;
+    width: 100%;
+    height: fit-content;
+  }
 }
 .q-tab-panels {
   height: calc(


### PR DESCRIPTION
## 内容

立ち絵の表示領域の高さが画像より大きい時は中央に、小さい時は上に張り付くような動きにしました

## スクリーンショット・動画など

https://user-images.githubusercontent.com/25514849/140191847-1b5a1f0b-2e5c-4b46-bfd4-828510136f2a.mp4
