### PR TITLE
ダイアログ表示にアニメーションを付ける

### DIFF
--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -2,8 +2,8 @@
   <q-dialog
     maximized
     seamless
-    transition-show="none"
-    transition-hide="none"
+    transition-show="jump-up"
+    transition-hide="jump-down"
     class="default-style-select-dialog"
     v-model="modelValueComputed"
   >

--- a/src/components/HelpDialog.vue
+++ b/src/components/HelpDialog.vue
@@ -2,8 +2,8 @@
   <q-dialog
     maximized
     seamless
-    transition-show="none"
-    transition-hide="none"
+    transition-show="jump-up"
+    transition-hide="jump-down"
     class="help-dialog"
     v-model="modelValueComputed"
   >

--- a/src/components/HotkeySettingDialog.vue
+++ b/src/components/HotkeySettingDialog.vue
@@ -2,8 +2,8 @@
   <q-dialog
     maximized
     seamless
-    transition-show="none"
-    transition-hide="none"
+    transition-show="jump-up"
+    transition-hide="jump-down"
     class="hotkey-setting-dialog"
     v-model="hotkeySettingDialogOpenComputed"
   >

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -2,8 +2,8 @@
   <q-dialog
     maximized
     seamless
-    transition-show="none"
-    transition-hide="none"
+    transition-show="jump-up"
+    transition-hide="jump-down"
     class="setting-dialog"
     v-model="settingDialogOpenedComputed"
   >


### PR DESCRIPTION
## 内容

ダイアログの遷移が唐突でどこが遷移したかわからないので、画面全体が遷移していることがわかるようにアニメーションを付けました。
これでどこがメインで、どういう階層にいるのかちょっと分かるようになったと思います。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など



https://user-images.githubusercontent.com/4987327/140194588-b05d552d-5cca-4cdf-86eb-bda78c53cc25.mp4


<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
