### PR TITLE
デフォルトスタイル選択画面のレイアウトを調整

### DIFF
--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -87,30 +87,31 @@
               :key="characterIndex"
               :name="characterIndex"
             >
-              <span class="text-h6">{{ characterInfo.metas.speakerName }}</span>
+              <div class="text-h6 character-name">
+                {{ characterInfo.metas.speakerName }}
+              </div>
 
-              <q-list class="q-mt-md q-pb-sm">
-                <q-item
-                  v-for="(style, styleIndex) of characterInfo.metas.styles"
-                  :key="styleIndex"
-                  v-ripple="isHoverableStyleItem"
-                  clickable
-                  class="q-mb-md q-pa-none style-item"
-                  :class="[
-                    selectedStyleIndexes[characterIndex] === styleIndex &&
-                      'active-style-item',
-                    isHoverableStyleItem && 'hoverable-style-item',
-                  ]"
-                  @click="selectedStyleIndexes[characterIndex] = styleIndex"
-                >
-                  <img :src="style.iconPath" class="style-icon" />
-                  <q-item-section>
-                    <q-item-label class="text-subtitle1 q-ma-md">{{
-                      style.styleName || "ノーマル"
-                    }}</q-item-label>
-                    <q-item-label class="q-ml-lg voice-samples">
-                      <span class="text-caption">音声サンプル</span>
-                      <div class="flex q-gutter-xs">
+              <div class="style-items-container">
+                <div class="q-pb-md">
+                  <q-item
+                    v-for="(style, styleIndex) of characterInfo.metas.styles"
+                    :key="styleIndex"
+                    clickable
+                    v-ripple="isHoverableStyleItem"
+                    class="q-pa-none style-item"
+                    :class="[
+                      selectedStyleIndexes[characterIndex] === styleIndex &&
+                        'active-style-item',
+                      isHoverableStyleItem && 'hoverable-style-item',
+                    ]"
+                    @click="selectedStyleIndexes[characterIndex] = styleIndex"
+                  >
+                    <div class="style-item-inner">
+                      <img :src="style.iconPath" class="style-icon" />
+                      <span class="text-subtitle1 q-ma-sm">{{
+                        style.styleName || "ノーマル"
+                      }}</span>
+                      <div class="voice-samples">
                         <q-btn
                           v-for="voiceSampleIndex of [...Array(3).keys()]"
                           :key="voiceSampleIndex"
@@ -133,16 +134,16 @@
                               : play(style, voiceSampleIndex)
                           "
                         />
+                        <q-radio
+                          class="absolute-top-right no-pointer-events"
+                          v-model="selectedStyleIndexes[characterIndex]"
+                          :val="styleIndex"
+                        />
                       </div>
-                    </q-item-label>
-                    <q-radio
-                      class="absolute-top-right no-pointer-events"
-                      v-model="selectedStyleIndexes[characterIndex]"
-                      :val="styleIndex"
-                    />
-                  </q-item-section>
-                </q-item>
-              </q-list>
+                    </div>
+                  </q-item>
+                </div>
+              </div>
             </q-tab-panel>
           </q-tab-panels>
         </q-page>
@@ -289,31 +290,63 @@ export default defineComponent({
 
   > :deep(.scroll) {
     overflow-y: scroll;
+    .q-tab-panel {
+      padding: 5px 16px;
+    }
   }
 
-  .style-item {
-    box-shadow: 0 0 0 1px rgba(global.$primary, 0.5);
-    border-radius: 10px;
-    overflow: hidden;
-    &.active-style-item {
-      box-shadow: 0 0 0 2px global.$primary;
-    }
-    &:hover :deep(.q-focus-helper) {
-      opacity: 0 !important;
-    }
-    &.hoverable-style-item:hover :deep(.q-focus-helper) {
-      opacity: 0.15 !important;
-    }
-    .style-icon {
-      width: 100px;
-      height: 100px;
-    }
-    .voice-samples {
+  $character-name-height: 30px;
+  .character-name {
+    height: $character-name-height;
+  }
+
+  .style-items-container {
+    display: grid;
+    align-items: center;
+    height: calc(100% - #{$character-name-height});
+    > div {
+      $style-item-size: 215px;
       display: grid;
-      grid-template-columns: auto 1fr;
-      align-items: center;
-      justify-items: center;
-      margin-top: 0;
+      grid-template-columns: repeat(auto-fit, $style-item-size);
+      grid-auto-rows: $style-item-size;
+      column-gap: 10px;
+      row-gap: 10px;
+      align-content: center;
+      justify-content: center;
+      .style-item {
+        box-shadow: 0 0 0 1px rgba(global.$primary, 0.5);
+        border-radius: 10px;
+        overflow: hidden;
+        &.active-style-item {
+          box-shadow: 0 0 0 2px global.$primary;
+        }
+        &:hover :deep(.q-focus-helper) {
+          opacity: 0 !important;
+        }
+        &.hoverable-style-item:hover :deep(.q-focus-helper) {
+          opacity: 0.15 !important;
+        }
+        .style-item-inner {
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          width: 100%;
+          height: 100%;
+          .style-icon {
+            $icon-size: $style-item-size / 2;
+            width: $icon-size;
+            height: $icon-size;
+            border-radius: 5px;
+          }
+          .voice-samples {
+            display: flex;
+            column-gap: 5px;
+            align-items: center;
+            justify-content: center;
+          }
+        }
+      }
     }
   }
 }
@@ -335,19 +368,6 @@ export default defineComponent({
     .q-page-sticky {
       left: 0 !important;
     }
-  }
-}
-
-@media screen and (max-width: 400px) {
-  .q-btn {
-    padding: 0 5px;
-  }
-  .style-icon {
-    width: 80px !important;
-    height: 80px !important;
-  }
-  .voice-sample-btn {
-    font-size: 8px;
   }
 }
 </style>


### PR DESCRIPTION
## 内容

右のスタイルアイテムをリストからカードにしました

## スクリーンショット・動画など

![image](https://user-images.githubusercontent.com/25514849/140527501-1c70faaf-273c-485e-afa9-6dbfed9f573c.png)
![image](https://user-images.githubusercontent.com/25514849/140527544-7387d574-79d8-4f2e-8afa-a585581dac58.png)
![image](https://user-images.githubusercontent.com/25514849/140532090-feec50b2-b011-4b0a-ae1f-cb024fdb68f5.png)

## その他

初回起動時のタイトルの「スタイル」を「喋り方」に変えるという話もありましたが、よく考えるとそこ以外は「スタイル」表記なのでちょっと微妙な気がしました
そのままにするか、いっそ全部変えるかのどちらかがいいかなと考えています

ということで、変更は一旦保留にしました