### PR TITLE
デフォルトスタイル選択時に音声を再生

### DIFF
--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -106,7 +106,7 @@
                         'active-style-item',
                       isHoverableStyleItem && 'hoverable-style-item',
                     ]"
-                    @click="selectedStyleIndexes[characterIndex] = styleIndex"
+                    @click="selectStyleIndex(characterIndex, styleIndex)"
                   >
                     <div class="style-item-inner">
                       <img :src="style.iconPath" class="style-icon" />
@@ -138,8 +138,11 @@
                         />
                         <q-radio
                           class="absolute-top-right no-pointer-events"
-                          v-model="selectedStyleIndexes[characterIndex]"
+                          :model-value="selectedStyleIndexes[characterIndex]"
                           :val="styleIndex"
+                          @update:model-value="
+                            selectStyleIndex(characterIndex, styleIndex)
+                          "
                         />
                       </div>
                     </div>
@@ -202,6 +205,22 @@ export default defineComponent({
       })
     );
 
+    const selectStyleIndex = (characterIndex: number, styleIndex: number) => {
+      selectedStyleIndexes.value[characterIndex] = styleIndex;
+
+      // 音声を再生する。同じstyleIndexだったら停止する。
+      const selectedStyleInfo =
+        props.characterInfos[characterIndex].metas.styles[styleIndex];
+      if (
+        playing.value !== undefined &&
+        playing.value.styleId === selectedStyleInfo.styleId
+      ) {
+        stop();
+      } else {
+        play(selectedStyleInfo, 0);
+      }
+    };
+
     const pageIndex = ref(0);
 
     const isHoverableStyleItem = ref(true);
@@ -258,6 +277,7 @@ export default defineComponent({
       modelValueComputed,
       isFirstTime,
       selectedStyleIndexes,
+      selectStyleIndex,
       pageIndex,
       isHoverableStyleItem,
       playing,

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -153,9 +153,9 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref } from "vue";
+import { defineComponent, computed, ref, PropType } from "vue";
 import { useStore } from "@/store";
-import { StyleInfo } from "@/type/preload";
+import { CharacterInfo, StyleInfo } from "@/type/preload";
 
 export default defineComponent({
   name: "DefaultStyleSelectDialog",
@@ -163,6 +163,11 @@ export default defineComponent({
   props: {
     modelValue: {
       type: Boolean,
+      required: true,
+    },
+
+    characterInfos: {
+      type: Object as PropType<CharacterInfo[]>,
       required: true,
     },
   },
@@ -182,10 +187,8 @@ export default defineComponent({
         isFirstTime.value = isUnsetDefaultStyleIds;
       });
 
-    const characterInfos = computed(() => store.state.characterInfos);
-
     const selectedStyleIndexes = ref(
-      characterInfos.value?.map((info) => {
+      props.characterInfos.map((info) => {
         const defaultStyleId = store.state.defaultStyleIds.find(
           (x) => x.speakerUuid === info.metas.speakerUuid
         )?.defaultStyleId;
@@ -231,9 +234,7 @@ export default defineComponent({
     };
 
     const closeDialog = () => {
-      if (!characterInfos.value) return;
-
-      const defaultStyleIds = characterInfos.value.map((info, idx) => ({
+      const defaultStyleIds = props.characterInfos.map((info, idx) => ({
         speakerUuid: info.metas.speakerUuid,
         defaultStyleId:
           info.metas.styles[selectedStyleIndexes.value?.[idx] ?? 0].styleId,
@@ -248,7 +249,6 @@ export default defineComponent({
     return {
       modelValueComputed,
       isFirstTime,
-      characterInfos,
       selectedStyleIndexes,
       pageIndex,
       isHoverableStyleItem,

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -49,6 +49,7 @@
               color="white"
               text-color="secondary"
               class="text-no-wrap"
+              :disable="!canNext"
               @click="nextPage"
             />
             <q-btn
@@ -58,6 +59,7 @@
               color="white"
               text-color="secondary"
               class="text-no-wrap"
+              :disable="!canNext"
               @click="closeDialog"
             />
           </div>
@@ -193,9 +195,10 @@ export default defineComponent({
           (x) => x.speakerUuid === info.metas.speakerUuid
         )?.defaultStyleId;
 
-        return info.metas.styles.findIndex(
+        const index = info.metas.styles.findIndex(
           (style) => style.styleId === defaultStyleId
         );
+        return index === -1 ? undefined : index;
       })
     );
 
@@ -208,6 +211,11 @@ export default defineComponent({
     const audio = new Audio();
     audio.volume = 0.7;
     audio.onended = () => stop();
+
+    const canNext = computed(() => {
+      const selectedStyleIndex = selectedStyleIndexes.value[pageIndex.value];
+      return selectedStyleIndex !== undefined;
+    });
 
     const play = ({ styleId, voiceSamplePaths }: StyleInfo, index: number) => {
       if (audio.src !== "") stop();
@@ -237,7 +245,7 @@ export default defineComponent({
       const defaultStyleIds = props.characterInfos.map((info, idx) => ({
         speakerUuid: info.metas.speakerUuid,
         defaultStyleId:
-          info.metas.styles[selectedStyleIndexes.value?.[idx] ?? 0].styleId,
+          info.metas.styles[selectedStyleIndexes.value[idx] ?? 0].styleId,
       }));
       store.dispatch("SET_DEFAULT_STYLE_IDS", defaultStyleIds);
 
@@ -253,6 +261,7 @@ export default defineComponent({
       pageIndex,
       isHoverableStyleItem,
       playing,
+      canNext,
       play,
       stop,
       prevPage,

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -170,7 +170,6 @@ export default defineComponent({
       type: Boolean,
       required: true,
     },
-
     characterInfos: {
       type: Object as PropType<CharacterInfo[]>,
       required: true,

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -228,7 +228,7 @@ export default defineComponent({
     const playing = ref<{ styleId: number; index: number }>();
 
     const audio = new Audio();
-    audio.volume = 0.7;
+    audio.volume = 0.5;
     audio.onended = () => stop();
 
     const canNext = computed(() => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -38,6 +38,29 @@ export const indexStore: VoiceVoxStoreOptions<
   mutations: {
     SET_DEFAULT_STYLE_IDS(state, { defaultStyleIds }) {
       state.defaultStyleIds = defaultStyleIds;
+
+      // 初期状態（空のAudioCellが１つだけ）だった場合は、スタイルを変更する
+      // FIXME: デフォルトスタイル選択前にAudioCellを生成しないようにする
+      if (state.audioKeys.length === 1) {
+        const audioItem = state.audioItems[state.audioKeys[0]];
+        if (audioItem.text === "") {
+          const characterInfo = state.characterInfos?.find(
+            (info) =>
+              info.metas.styles.find(
+                (style) => style.styleId == audioItem.styleId
+              ) != undefined
+          );
+          if (characterInfo == undefined)
+            throw new Error("characterInfo == undefined");
+
+          const speakerUuid = characterInfo.metas.speakerUuid;
+          const defaultStyleId = defaultStyleIds.find(
+            (styleId) => speakerUuid == styleId.speakerUuid
+          )?.defaultStyleId;
+
+          audioItem.styleId = defaultStyleId;
+        }
+      }
     },
   },
   actions: {

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -108,7 +108,6 @@
   <help-dialog v-model="isHelpDialogOpenComputed" />
   <setting-dialog v-model="isSettingDialogOpenComputed" />
   <hotkey-setting-dialog v-model="isHotkeySettingDialogOpenComputed" />
-  <!-- v-ifも付けないとfalseでも動いてしまう -->
   <default-style-select-dialog
     v-if="characterInfos"
     :characterInfos="characterInfos"

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -110,7 +110,8 @@
   <hotkey-setting-dialog v-model="isHotkeySettingDialogOpenComputed" />
   <!-- v-ifも付けないとfalseでも動いてしまう -->
   <default-style-select-dialog
-    v-if="isDefaultStyleSelectDialogOpenComputed"
+    v-if="characterInfos"
+    :characterInfos="characterInfos"
     v-model="isDefaultStyleSelectDialogOpenComputed"
   />
 </template>
@@ -401,6 +402,7 @@ export default defineComponent({
     });
 
     // デフォルトスタイル選択
+    const characterInfos = computed(() => store.state.characterInfos);
     const isDefaultStyleSelectDialogOpenComputed = computed({
       get: () => store.state.isDefaultStyleSelectDialogOpen,
       set: (val) =>
@@ -454,6 +456,7 @@ export default defineComponent({
       isHelpDialogOpenComputed,
       isSettingDialogOpenComputed,
       isHotkeySettingDialogOpenComputed,
+      characterInfos,
       isDefaultStyleSelectDialogOpenComputed,
       dragEventCounter,
       loadDraggedFile,


### PR DESCRIPTION
## 内容

デフォルトスタイル選択時に音声を再生するようにしてみました。
あと未選択の場合は進めなくしました。
あと https://github.com/Hiroshiba/voicevox/issues/439 をついでに解決しました

## 関連 Issue

close: #439 
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他

