### PR TITLE
デフォルトスタイルダイアログが開かれたタイミングで初期値を代入する

### DIFF
--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -158,7 +158,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, PropType } from "vue";
+import { defineComponent, computed, ref, PropType, watch } from "vue";
 import { useStore } from "@/store";
 import { CharacterInfo, StyleInfo } from "@/type/preload";
 
@@ -185,23 +185,34 @@ export default defineComponent({
     });
 
     const isFirstTime = ref(false);
-    store
-      .dispatch("IS_UNSET_DEFAULT_STYLE_IDS")
-      .then((isUnsetDefaultStyleIds) => {
-        isFirstTime.value = isUnsetDefaultStyleIds;
-      });
+    const selectedStyleIndexes = ref<(number | undefined)[]>([]);
 
-    const selectedStyleIndexes = ref(
-      props.characterInfos.map((info) => {
-        const defaultStyleId = store.state.defaultStyleIds.find(
-          (x) => x.speakerUuid === info.metas.speakerUuid
-        )?.defaultStyleId;
+    // ダイアログが開かれたときに初期値を求める
+    watch(
+      () => props.modelValue,
+      (newValue, oldValue) => {
+        if (!oldValue && newValue) {
+          store
+            .dispatch("IS_UNSET_DEFAULT_STYLE_IDS")
+            .then((isUnsetDefaultStyleIds) => {
+              isFirstTime.value = isUnsetDefaultStyleIds;
+            });
 
-        const index = info.metas.styles.findIndex(
-          (style) => style.styleId === defaultStyleId
-        );
-        return index === -1 ? undefined : index;
-      })
+          selectedStyleIndexes.value = props.characterInfos.map((info) => {
+            // FIXME: キャラクターごとにデフォルスタイル選択済みか保存できるようになるべき
+            if (isFirstTime.value) return undefined;
+
+            const defaultStyleId = store.state.defaultStyleIds.find(
+              (x) => x.speakerUuid === info.metas.speakerUuid
+            )?.defaultStyleId;
+
+            const index = info.metas.styles.findIndex(
+              (style) => style.styleId === defaultStyleId
+            );
+            return index === -1 ? undefined : index;
+          });
+        }
+      }
     );
 
     const selectStyleIndex = (characterIndex: number, styleIndex: number) => {


### PR DESCRIPTION
## 内容

ダイアログが生成されるタイミングと表示されるタイミングが違って、ユーザーの意図と異なる初期値が入っていました。
（ソフトウェア再起動後にデフォルトスタイルダイアログを開くと以前のスタイルが選ばれていない、など）

開かれたときに初期値を再度生成するようにしました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
