### PR TITLE
nsis-web インストーラーでのダウンロード処理にタイムアウト時間の指定を追加

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -7,6 +7,11 @@
 ; !define DOWNLOAD_BASE_URL "http://127.0.0.1:8080"
 !define DOWNLOAD_BASE_URL "${APP_PACKAGE_URL}"
 
+; inetc::get で使用するタイムアウト時間（秒）
+; https://nsis.sourceforge.io/Inetc_plug-in#Commands
+!define CONNECTTIMEOUT "300"
+!define RECEIVETIMEOUT "300"
+
 !ifndef BUILD_UNINSTALLER
 
   ; インストール後のサイズ
@@ -130,7 +135,7 @@
   Exch $0            ;       $0
   Push $1            ;       $1 $0
 
-  inetc::get /POPUP "" /CAPTION "$(^Name) セットアップ" /RESUME "追加ファイルのダウンロードに失敗しました。$\r$\n再試行しますか？" "${DOWNLOAD_BASE_URL}/$archiveName.ini" "$0" /END
+  inetc::get /CONNECTTIMEOUT ${CONNECTTIMEOUT} /RECEIVETIMEOUT ${RECEIVETIMEOUT} /POPUP "" /CAPTION "$(^Name) セットアップ" /RESUME "追加ファイルのダウンロードに失敗しました。$\r$\n再試行しますか？" "${DOWNLOAD_BASE_URL}/$archiveName.ini" "$0" /END
   Pop $0
 
                   ; Stack $1 $0
@@ -222,7 +227,7 @@ verifyPartedFile_finish${UniqueID}:
     Goto downloadFile_finish
   ${EndIf}
 
-  inetc::get /POPUP "" /CAPTION "$(^Name) セットアップ ($3/$numFiles)" /RESUME "ファイルのダウンロード中にエラーが発生しました。$\r$\n再試行しますか？" "${DOWNLOAD_BASE_URL}/$archiveName.$2" "$4" /END
+  inetc::get /CONNECTTIMEOUT ${CONNECTTIMEOUT} /RECEIVETIMEOUT ${RECEIVETIMEOUT} /POPUP "" /CAPTION "$(^Name) セットアップ ($3/$numFiles)" /RESUME "ファイルのダウンロード中にエラーが発生しました。$\r$\n再試行しますか？" "${DOWNLOAD_BASE_URL}/$archiveName.$2" "$4" /END
   Pop $0
 
   ; プロキシーなしでリトライする処理は合理的な理由が見つからないのでひとまずやめる
@@ -230,7 +235,7 @@ verifyPartedFile_finish${UniqueID}:
   ; https://github.com/electron-userland/electron-builder/issues/2049
   ; ${If} $0 != "OK"
   ; ${AndIf} $0 != "Cancelled"
-  ;   inetc::get /NOPROXY /POPUP "" /CAPTION "$(^Name) セットアップ ($3/$numFiles)" /RESUME "ファイルのダウンロード中にエラーが発生しました。$\r$\n再試行しますか？" "${DOWNLOAD_BASE_URL}/$archiveName.$2" "$4" /END
+  ;   inetc::get /CONNECTTIMEOUT ${CONNECTTIMEOUT} /RECEIVETIMEOUT ${RECEIVETIMEOUT} /NOPROXY /POPUP "" /CAPTION "$(^Name) セットアップ ($3/$numFiles)" /RESUME "ファイルのダウンロード中にエラーが発生しました。$\r$\n再試行しますか？" "${DOWNLOAD_BASE_URL}/$archiveName.$2" "$4" /END
   ;   Pop $0
   ; ${EndIf}
 

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -219,6 +219,7 @@ import {
   onUnmounted,
   reactive,
   ref,
+  watch,
 } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
@@ -306,6 +307,17 @@ export default defineComponent({
     const query = computed(() => audioItem.value?.query);
     const accentPhrases = computed(() => query.value?.accentPhrases);
 
+    const lastPitches = ref<number[][]>([]);
+    watch(accentPhrases, (newPhrases) => {
+      if (newPhrases) {
+        lastPitches.value = newPhrases.map((phrase) =>
+          phrase.moras.map((mora) => mora.pitch)
+        );
+      } else {
+        lastPitches.value = [];
+      }
+    });
+
     const changeAccent = (accentPhraseIndex: number, accent: number) =>
       store.dispatch("COMMAND_CHANGE_ACCENT", {
         audioKey: props.activeAudioKey,
@@ -332,6 +344,9 @@ export default defineComponent({
       data: number,
       type: MoraDataType
     ) => {
+      if (type == "pitch") {
+        lastPitches.value[accentPhraseIndex][moraIndex] = data;
+      }
       store.dispatch("COMMAND_SET_AUDIO_MORA_DATA", {
         audioKey: props.activeAudioKey,
         accentPhraseIndex,
@@ -594,7 +609,12 @@ export default defineComponent({
         ) {
           let data = 0;
           if (mora.pitch == 0) {
-            data = 5.5; // don't worry, it will be overwritten by template itself
+            if (lastPitches.value[accentPhraseIndex][moraIndex] == 0) {
+              // 元々無声だった場合、適当な値を代入
+              data = 5.5;
+            } else {
+              data = lastPitches.value[accentPhraseIndex][moraIndex];
+            }
           }
           changeMoraData(accentPhraseIndex, moraIndex, data, "voicing");
         }

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -33,7 +33,7 @@
 <script lang="ts">
 import { previewSliderHelper } from "@/helpers/previewSliderHelper";
 import { MoraDataType } from "@/type/preload";
-import { computed, defineComponent, reactive, ref, watch } from "vue";
+import { computed, defineComponent, reactive } from "vue";
 
 export default defineComponent({
   name: "AudioParameter",
@@ -55,8 +55,6 @@ export default defineComponent({
   emits: ["changeValue", "mouseOver"],
 
   setup(props, { emit }) {
-    const lastPitch = ref<number>(props.value);
-
     const changeValue = (newValue: number, type: MoraDataType = props.type) => {
       emit(
         "changeValue",
@@ -116,21 +114,6 @@ export default defineComponent({
       }
     });
 
-    watch(
-      () => props.value,
-      (newVal, oldVal) => {
-        if (props.type == "pitch" && lastPitch.value != 0) {
-          if (newVal != 0) {
-            if (oldVal == 0) {
-              changeValue(lastPitch.value as number, "voicing");
-            } else {
-              lastPitch.value = newVal;
-            }
-          }
-        }
-      }
-    );
-
     return {
       previewSlider,
       changeValue,
@@ -138,7 +121,6 @@ export default defineComponent({
       clipPathComputed,
       handleMouseHover,
       precisionComputed,
-      lastPitch,
     };
   },
 });


### PR DESCRIPTION
## 内容

すべての環境で同じ挙動かはわかりませんが、少なくとも11月7日5時時点の私の環境においては
[voicevox-0.8.0-x64.nsis.7z.1](https://github.com/Hiroshiba/voicevox/releases/download/0.8.0/voicevox-0.8.0-x64.nsis.7z.1) をブラウザでダウンロードすると進捗ゲージが表示されるまでに40秒程度掛かり、
この最初の待ち時間でインストーラーがタイムアウトしているのか、ダウンロードに失敗します。

この失敗を回避するため、明示的に **5分** のタイムアウト時間を指定するようにします。
これは「1GBを5分以内に全部ダウンロードできないとタイムアウト」ではなく、
「5分以内にデータを何も落とせないとタイムアウト」のはずなので、
一般的には充分に長い設定だと思われます。

## 関連 Issue

close #448
