### PR TITLE
無声化処理のexperimentalタグを外しデフォルトで有効にする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -66,7 +66,6 @@ const store = new Store<{
   savingSetting: SavingSetting;
   hotkeySettings: HotkeySetting[];
   defaultStyleIds: DefaultStyleId[];
-  useVoicing: boolean;
 }>({
   schema: {
     useGpu: {
@@ -198,10 +197,6 @@ const store = new Store<{
         },
       },
       default: [],
-    },
-    useVoicing: {
-      type: "boolean",
-      default: false,
     },
   },
   migrations: {
@@ -634,13 +629,6 @@ ipcMainHandle("HOTKEY_SETTINGS", (_, { newData }) => {
     store.set("hotkeySettings", hotkeySettings);
   }
   return store.get("hotkeySettings");
-});
-
-ipcMainHandle("USE_VOICING", (_, { newData }) => {
-  if (newData !== undefined) {
-    store.set("useVoicing", newData);
-  }
-  return store.get("useVoicing");
 });
 
 ipcMainHandle("CHECK_FILE_EXISTS", (_, { file }) => {

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -219,6 +219,7 @@ import {
   onUnmounted,
   reactive,
   ref,
+  watch,
 } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
@@ -306,6 +307,17 @@ export default defineComponent({
     const query = computed(() => audioItem.value?.query);
     const accentPhrases = computed(() => query.value?.accentPhrases);
 
+    const lastPitches = ref<number[][]>([]);
+    watch(accentPhrases, (newPhrases) => {
+      if (newPhrases) {
+        lastPitches.value = newPhrases.map((phrase) =>
+          phrase.moras.map((mora) => mora.pitch)
+        );
+      } else {
+        lastPitches.value = [];
+      }
+    });
+
     const changeAccent = (accentPhraseIndex: number, accent: number) =>
       store.dispatch("COMMAND_CHANGE_ACCENT", {
         audioKey: props.activeAudioKey,
@@ -332,6 +344,9 @@ export default defineComponent({
       data: number,
       type: MoraDataType
     ) => {
+      if (type == "pitch") {
+        lastPitches.value[accentPhraseIndex][moraIndex] = data;
+      }
       store.dispatch("COMMAND_SET_AUDIO_MORA_DATA", {
         audioKey: props.activeAudioKey,
         accentPhraseIndex,
@@ -594,7 +609,12 @@ export default defineComponent({
         ) {
           let data = 0;
           if (mora.pitch == 0) {
-            data = 5.5; // don't worry, it will be overwritten by template itself
+            if (lastPitches.value[accentPhraseIndex][moraIndex] == 0) {
+              // 元々無声だった場合、適当な値を代入
+              data = 5.5;
+            } else {
+              data = lastPitches.value[accentPhraseIndex][moraIndex];
+            }
           }
           changeMoraData(accentPhraseIndex, moraIndex, data, "voicing");
         }

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -296,7 +296,6 @@ export default defineComponent({
     const selectDetail = (index: number) => {
       selectedDetail.value = index === 0 ? "accent" : "pitch";
     };
-    const useVoicing = computed(() => store.state.useVoicing);
 
     // accent phrase
     const uiLocked = computed(() => store.getters.UI_LOCKED);
@@ -540,7 +539,7 @@ export default defineComponent({
       }
     };
 
-    const unvoicableVowels = ["U", "I", "i", "u"];
+    const unvoicableVowels = ["A", "I", "U", "E", "O", "a", "i", "u", "e", "o"];
 
     const getHoveredClass = (
       vowel: string,
@@ -553,7 +552,7 @@ export default defineComponent({
           if (accentPhraseIndex === accentHoveredInfo.accentPhraseIndex) {
             isHover = true;
           }
-        } else if (selectedDetail.value == "pitch" && useVoicing.value) {
+        } else if (selectedDetail.value == "pitch") {
           if (
             accentPhraseIndex === pitchHoveredInfo.accentPhraseIndex &&
             moraIndex === pitchHoveredInfo.moraIndex &&
@@ -602,7 +601,7 @@ export default defineComponent({
       accentPhraseIndex: number,
       moraIndex: number
     ) => {
-      if (!uiLocked.value && useVoicing.value) {
+      if (!uiLocked.value) {
         if (
           selectedDetail.value == "pitch" &&
           unvoicableVowels.indexOf(mora.vowel) > -1

--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -539,7 +539,7 @@ export default defineComponent({
       }
     };
 
-    const unvoicableVowels = ["A", "I", "U", "E", "O", "a", "i", "u", "e", "o"];
+    const unvoicableVowels = ["U", "I", "i", "u"];
 
     const getHoveredClass = (
       vowel: string,

--- a/src/components/AudioParameter.vue
+++ b/src/components/AudioParameter.vue
@@ -33,7 +33,7 @@
 <script lang="ts">
 import { previewSliderHelper } from "@/helpers/previewSliderHelper";
 import { MoraDataType } from "@/type/preload";
-import { computed, defineComponent, reactive, ref, watch } from "vue";
+import { computed, defineComponent, reactive } from "vue";
 
 export default defineComponent({
   name: "AudioParameter",
@@ -55,8 +55,6 @@ export default defineComponent({
   emits: ["changeValue", "mouseOver"],
 
   setup(props, { emit }) {
-    const lastPitch = ref<number>(props.value);
-
     const changeValue = (newValue: number, type: MoraDataType = props.type) => {
       emit(
         "changeValue",
@@ -116,21 +114,6 @@ export default defineComponent({
       }
     });
 
-    watch(
-      () => props.value,
-      (newVal, oldVal) => {
-        if (props.type == "pitch" && lastPitch.value != 0) {
-          if (newVal != 0) {
-            if (oldVal == 0) {
-              changeValue(lastPitch.value as number, "voicing");
-            } else {
-              lastPitch.value = newVal;
-            }
-          }
-        }
-      }
-    );
-
     return {
       previewSlider,
       changeValue,
@@ -138,7 +121,6 @@ export default defineComponent({
       clipPathComputed,
       handleMouseHover,
       precisionComputed,
-      lastPitch,
     };
   },
 });

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -285,26 +285,12 @@
                 </q-select>
               </q-card-actions> -->
             </q-card>
-            <q-card flat class="setting-card">
+            <!-- 今後実験的機能を追加する場合はここに追加 -->
+            <!-- <q-card flat class="setting-card">
               <q-card-actions>
                 <div class="text-h5">実験的機能</div>
               </q-card-actions>
-              <q-card-actions class="q-px-md q-py-sm bg-grey-3">
-                <div>無声化切り替え</div>
-                <q-space />
-                <q-toggle v-model="useVoicingComputed">
-                  <q-tooltip
-                    :delay="500"
-                    anchor="center left"
-                    self="center right"
-                    transition-show="jump-left"
-                    transition-hide="jump-right"
-                  >
-                    この機能を有効にすると、元に戻す・やり直す機能が正しく動作しなくなる可能性があります
-                  </q-tooltip>
-                </q-toggle>
-              </q-card-actions>
-            </q-card>
+            </q-card> -->
           </div>
         </q-page>
       </q-page-container>
@@ -344,13 +330,6 @@ export default defineComponent({
       },
     });
     const inheritAudioInfoMode = computed(() => store.state.inheritAudioInfo);
-
-    const useVoicingComputed = computed({
-      get: () => store.state.useVoicing,
-      set: (useVoicing: boolean) => {
-        store.dispatch("SET_USE_VOICING", { data: useVoicing });
-      },
-    });
 
     const changeUseGPU = async (useGpu: boolean) => {
       if (store.state.useGpu === useGpu) return;
@@ -474,7 +453,6 @@ export default defineComponent({
       savingSetting,
       handleSavingSettingChange,
       openFileExplore,
-      useVoicingComputed,
     };
   },
 });

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -195,10 +195,6 @@ const api: Sandbox = {
   setDefaultStyleIds: async (defaultStyleIds) => {
     await ipcRendererInvoke("SET_DEFAULT_STYLE_IDS", defaultStyleIds);
   },
-
-  useVoicing: (newData) => {
-    return ipcRenderer.invoke("USE_VOICING", { newData });
-  },
 };
 
 contextBridge.exposeInMainWorld("electron", api);

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -28,7 +28,6 @@ export const settingStoreState: SettingStoreState = {
     outputSamplingRate: 24000,
   },
   hotkeySettings: [],
-  useVoicing: false,
   engineHost: process.env.VUE_APP_ENGINE_URL as unknown as string,
 };
 
@@ -58,9 +57,6 @@ export const settingStore: VoiceVoxStoreOptions<
         }
       });
       if (flag) state.hotkeySettings.push(newHotkey);
-    },
-    SET_USE_VOICING(state, { useVoicing }: { useVoicing: boolean }) {
-      state.useVoicing = useVoicing;
     },
   },
   actions: {
@@ -107,15 +103,6 @@ export const settingStore: VoiceVoxStoreOptions<
       commit("SET_HOTKEY_SETTINGS", {
         newHotkey: data,
       });
-    },
-    GET_USE_VOICING({ commit }) {
-      window.electron.useVoicing().then((useVoicing) => {
-        commit("SET_USE_VOICING", { useVoicing: useVoicing });
-      });
-    },
-    SET_USE_VOICING({ commit }, { data }: { data: boolean }) {
-      window.electron.useVoicing(data);
-      commit("SET_USE_VOICING", { useVoicing: data });
     },
   },
 };

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -605,7 +605,6 @@ export type ProjectActions = StoreType<ProjectStoreTypes, "action">;
 export type SettingStoreState = {
   savingSetting: SavingSetting;
   hotkeySettings: HotkeySetting[];
-  useVoicing: boolean;
   engineHost: string;
 };
 
@@ -627,15 +626,6 @@ type SettingStoreTypes = {
   SET_HOTKEY_SETTINGS: {
     mutation: { newHotkey: HotkeySetting };
     action(payload: { data: HotkeySetting }): void;
-  };
-
-  GET_USE_VOICING: {
-    action(): void;
-  };
-
-  SET_USE_VOICING: {
-    mutation: { useVoicing: boolean };
-    action(payload: { data: boolean }): void;
   };
 };
 

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -53,7 +53,6 @@ export interface Sandbox {
   setDefaultStyleIds(
     defaultStyleIds: { speakerUuid: string; defaultStyleId: number }[]
   ): Promise<void>;
-  useVoicing(newData?: boolean): Promise<boolean>;
 }
 
 export type AppInfos = {

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -44,7 +44,6 @@ describe("store/vuex.js test", () => {
         },
         isPinned: false,
         hotkeySettings: [],
-        useVoicing: false,
         engineHost: "http://127.0.0.1",
       },
       getters: {
@@ -110,6 +109,5 @@ describe("store/vuex.js test", () => {
     assert.equal(store.state.isPinned, false);
     assert.isArray(store.state.hotkeySettings);
     assert.isEmpty(store.state.hotkeySettings);
-    assert.equal(store.state.useVoicing, false);
   });
 });


### PR DESCRIPTION
## 内容
undo/redoが安定したので無声化処理をデフォルトで有効にする

ref: https://github.com/Hiroshiba/voicevox/pull/435#pullrequestreview-799461061

## 関連 Issue
無声化についての説明をどこかに置いておく必要がありそう
ref: #243 


<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など
ユーザーによる無声化とデフォルト無声で微妙に表示がことなるのですが無視してもいいですか？

ユーザーによる無声化
![image](https://user-images.githubusercontent.com/8027142/140637942-bd7d510e-9fcf-4315-a876-0a401f49036e.png)

audioquery時にデフォルトで無声化
![image](https://user-images.githubusercontent.com/8027142/140637952-195be983-505a-42de-8262-f0abf4b0d71d.png)


## その他
