### PR TITLE
音声を１つだけ書き出す機能をメニューに付ける

### DIFF
--- a/src/components/AudioDetail.vue
+++ b/src/components/AudioDetail.vue
@@ -223,7 +223,6 @@ import {
 } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
-import { SaveResultObject } from "@/store/type";
 import AudioAccent from "./AudioAccent.vue";
 import AudioParameter from "./AudioParameter.vue";
 import { HotkeyAction, HotkeyReturnType, MoraDataType } from "@/type/preload";
@@ -251,14 +250,6 @@ export default defineComponent({
             play();
           } else {
             stop();
-          }
-        },
-      ],
-      [
-        "一つだけ書き出し",
-        () => {
-          if (!uiLocked.value) {
-            save();
           }
         },
       ],
@@ -355,20 +346,6 @@ export default defineComponent({
       });
     };
 
-    const tabAction = (actionType: DetailTypes) => {
-      switch (actionType) {
-        case "play":
-          play();
-          break;
-        case "stop":
-          stop();
-          break;
-        case "save":
-          save();
-          break;
-      }
-    };
-
     // audio play
     const play = async () => {
       try {
@@ -390,41 +367,6 @@ export default defineComponent({
 
     const stop = () => {
       store.dispatch("STOP_AUDIO", { audioKey: props.activeAudioKey });
-    };
-
-    // save
-    const save = async () => {
-      const result: SaveResultObject = await store.dispatch(
-        "GENERATE_AND_SAVE_AUDIO",
-        {
-          audioKey: props.activeAudioKey,
-          encoding: store.state.savingSetting.fileEncoding,
-        }
-      );
-
-      if (result.result === "SUCCESS" || result.result === "CANCELED") return;
-
-      let msg = "";
-      switch (result.result) {
-        case "WRITE_ERROR":
-          msg =
-            "書き込みエラーによって失敗しました。空き容量があることや、書き込み権限があることをご確認ください。";
-          break;
-        case "ENGINE_ERROR":
-          msg =
-            "エンジンのエラーによって失敗しました。エンジンの再起動をお試しください。";
-          break;
-      }
-
-      $q.dialog({
-        title: "書き出しに失敗しました。",
-        message: msg,
-        ok: {
-          label: "閉じる",
-          flat: true,
-          textColor: "secondary",
-        },
-      });
     };
 
     const nowPlaying = computed(
@@ -642,7 +584,6 @@ export default defineComponent({
       changeMoraData,
       play,
       stop,
-      save,
       nowPlaying,
       nowGenerating,
       nowPlayingContinuously,
@@ -653,7 +594,6 @@ export default defineComponent({
       getHoveredClass,
       getHoveredText,
       shiftKeyFlag,
-      tabAction,
       handleChangeVoicing,
     };
   },


### PR DESCRIPTION
## 内容

音声を１つだけ書き出す機能をメニューに付けました。
これで（クリック数は多いですが）コーヒー片手に音声を１つ書き出すことができます。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
