### PR TITLE
保存確認ダイアログのボタンを「OK」から「破棄」に変更

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -498,6 +498,20 @@ ipcMainHandle("SHOW_CONFIRM_DIALOG", (_, { title, message }) => {
     });
 });
 
+ipcMainHandle("SHOW_INFO_DIALOG", (_, { title, message, buttons }) => {
+  return dialog
+    .showMessageBox(win, {
+      type: "info",
+      buttons: buttons,
+      title: title,
+      message: message,
+      noLink: true,
+    })
+    .then((value) => {
+      return value.response;
+    });
+});
+
 ipcMainHandle("SHOW_WARNING_DIALOG", (_, { title, message }) => {
   return dialog.showMessageBox(win, {
     type: "warning",

--- a/src/background.ts
+++ b/src/background.ts
@@ -485,19 +485,6 @@ ipcMainHandle("SHOW_PROJECT_LOAD_DIALOG", (_, { title }) => {
   });
 });
 
-ipcMainHandle("SHOW_CONFIRM_DIALOG", (_, { title, message }) => {
-  return dialog
-    .showMessageBox(win, {
-      type: "info",
-      buttons: ["OK", "Cancel"],
-      title: title,
-      message: message,
-    })
-    .then((value) => {
-      return value.response == 0;
-    });
-});
-
 ipcMainHandle("SHOW_INFO_DIALOG", (_, { title, message, buttons }) => {
   return dialog
     .showMessageBox(win, {

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -100,10 +100,6 @@ const api: Sandbox = {
     return ipcRendererInvoke("SHOW_PROJECT_LOAD_DIALOG", { title });
   },
 
-  showConfirmDialog: ({ title, message }) => {
-    return ipcRendererInvoke("SHOW_CONFIRM_DIALOG", { title, message });
-  },
-
   showInfoDialog: ({ title, message, buttons }) => {
     return ipcRendererInvoke("SHOW_INFO_DIALOG", { title, message, buttons });
   },

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -104,6 +104,10 @@ const api: Sandbox = {
     return ipcRendererInvoke("SHOW_CONFIRM_DIALOG", { title, message });
   },
 
+  showInfoDialog: ({ title, message, buttons }) => {
+    return ipcRendererInvoke("SHOW_INFO_DIALOG", { title, message, buttons });
+  },
+
   showWarningDialog: ({ title, message }) => {
     return ipcRendererInvoke("SHOW_WARNING_DIALOG", { title, message });
   },

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -48,17 +48,17 @@ export const projectStore: VoiceVoxStoreOptions<
   actions: {
     CREATE_NEW_PROJECT: createUILockAction(
       async (context, { confirm }: { confirm?: boolean }) => {
-        if (
-          confirm !== false &&
-          context.getters.IS_EDITED &&
-          !(await window.electron.showConfirmDialog({
+        if (confirm !== false && context.getters.IS_EDITED) {
+          const result: number = await window.electron.showInfoDialog({
             title: "警告",
             message:
               "プロジェクトの変更が保存されていません。\n" +
               "変更を破棄してもよろしいですか？",
-          }))
-        ) {
-          return;
+            buttons: ["破棄", "キャンセル"],
+          });
+          if (result == 1) {
+            return;
+          }
         }
 
         await context.dispatch("REMOVE_ALL_AUDIO_ITEM", undefined);
@@ -230,17 +230,17 @@ export const projectStore: VoiceVoxStoreOptions<
             );
           }
 
-          if (
-            confirm !== false &&
-            context.getters.IS_EDITED &&
-            !(await window.electron.showConfirmDialog({
+          if (confirm !== false && context.getters.IS_EDITED) {
+            const result: number = await window.electron.showInfoDialog({
               title: "警告",
               message:
                 "プロジェクトをロードすると現在のプロジェクトは破棄されます。\n" +
                 "変更を破棄してもよろしいですか？",
-            }))
-          ) {
-            return;
+              buttons: ["破棄", "キャンセル"],
+            });
+            if (result == 1) {
+              return;
+            }
           }
           await context.dispatch("REMOVE_ALL_AUDIO_ITEM", undefined);
 

--- a/src/store/ui.ts
+++ b/src/store/ui.ts
@@ -206,16 +206,17 @@ export const uiStore: VoiceVoxStoreOptions<UiGetters, UiActions, UiMutations> =
         commit("DETECT_UNPINNED");
       },
       async CHECK_EDITED_AND_NOT_SAVE({ getters }) {
-        if (
-          getters.IS_EDITED &&
-          !(await window.electron.showConfirmDialog({
+        if (getters.IS_EDITED) {
+          const result: number = await window.electron.showInfoDialog({
             title: "警告",
             message:
               "プロジェクトの変更が保存されていません。\n" +
               "変更を破棄してもよろしいですか？",
-          }))
-        ) {
-          return;
+            buttons: ["破棄", "キャンセル"],
+          });
+          if (result == 1) {
+            return;
+          }
         }
 
         window.electron.closeWindow();

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -67,11 +67,6 @@ type IpcIHData = {
     return?: string[];
   };
 
-  SHOW_CONFIRM_DIALOG: {
-    args: [obj: { title: string; message: string }];
-    return: boolean;
-  };
-
   SHOW_INFO_DIALOG: {
     args: [obj: { title: string; message: string; buttons: string[] }];
     return: number;

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -72,6 +72,11 @@ type IpcIHData = {
     return: boolean;
   };
 
+  SHOW_INFO_DIALOG: {
+    args: [obj: { title: string; message: string; buttons: string[] }];
+    return: number;
+  };
+
   SHOW_WARNING_DIALOG: {
     args: [obj: { title: string; message: string }];
     return: Electron.MessageBoxReturnValue;

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -19,6 +19,11 @@ export interface Sandbox {
   showProjectSaveDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
   showConfirmDialog(obj: { title: string; message: string }): Promise<boolean>;
+  showInfoDialog(obj: {
+    title: string;
+    message: string;
+    buttons: string[];
+  }): Promise<number>;
   showWarningDialog(obj: {
     title: string;
     message: string;

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -18,7 +18,6 @@ export interface Sandbox {
   showOpenDirectoryDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectSaveDialog(obj: { title: string }): Promise<string | undefined>;
   showProjectLoadDialog(obj: { title: string }): Promise<string[] | undefined>;
-  showConfirmDialog(obj: { title: string; message: string }): Promise<boolean>;
   showInfoDialog(obj: {
     title: string;
     message: string;


### PR DESCRIPTION
## 内容
変更が保存されていないときの終了時に表示されるダイアログのボタンを「OK」から「破棄」に変更しました。

新たに、showInfoDialogメソッドを作成しました。
引数にbuttonsを定義し、ボタンを自由に設定できるようにしました。
また、戻り値を押されたボタンのインデックスにしました。

## 関連 Issue
#467

## スクリーンショット・動画など
![スクリーンショット 2021-11-15 225021](https://user-images.githubusercontent.com/32050537/141793150-e7807bc6-0666-4fec-ad26-ee93b09de934.png)

## その他
TypeScript初めてなので、至らぬ点があればご指摘ください。
