### PR TITLE
音声の再生デバイスを変更できるようにする

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -164,7 +164,7 @@ const store = new Store<{
         exportText: { type: "boolean", default: true },
         outputStereo: { type: "boolean", default: false },
         outputSamplingRate: { type: "number", default: 24000 },
-        audioOutputDevice: { type: "string", default: "" },
+        audioOutputDevice: { type: "string", default: "default" },
       },
       default: {
         fileEncoding: "UTF-8",
@@ -175,7 +175,7 @@ const store = new Store<{
         exportText: true,
         outputStereo: false,
         outputSamplingRate: 24000,
-        audioOutputDevice: "",
+        audioOutputDevice: "default",
       },
     },
     // To future developers: if you are to modify the store schema with array type,

--- a/src/background.ts
+++ b/src/background.ts
@@ -164,6 +164,7 @@ const store = new Store<{
         exportText: { type: "boolean", default: true },
         outputStereo: { type: "boolean", default: false },
         outputSamplingRate: { type: "number", default: 24000 },
+        audioOutputDevice: { type: "string", default: "" },
       },
       default: {
         fileEncoding: "UTF-8",
@@ -174,6 +175,7 @@ const store = new Store<{
         exportText: true,
         outputStereo: false,
         outputSamplingRate: 24000,
+        audioOutputDevice: "",
       },
     },
     // To future developers: if you are to modify the store schema with array type,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -396,20 +396,25 @@ export default defineComponent({
       });
     });
 
-    const currentAudioOutputDeviceComputed = computed({
+    const currentAudioOutputDeviceComputed = computed<{
+      key: string;
+      label: string;
+    } | null>({
       get: () => {
         const device = availableAudioOutputDevices.value?.find(
           (device) => device.key === store.state.savingSetting.audioOutputDevice
         );
         if (device) {
-          return device.label;
+          return device;
         } else {
           handleSavingSettingChange("audioOutputDevice", "default");
           return null;
         }
       },
-      set: (device: any) => {
-        handleSavingSettingChange("audioOutputDevice", device.key);
+      set: (device) => {
+        if (device) {
+          handleSavingSettingChange("audioOutputDevice", device.key);
+        }
       },
     });
 

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -401,7 +401,7 @@ export default defineComponent({
       label: string;
     } | null>({
       get: () => {
-        //見つからなかったらデフォルト値に戻す
+        // 再生デバイスが見つからなかったらデフォルト値に戻す
         const device = availableAudioOutputDevices.value?.find(
           (device) => device.key === store.state.savingSetting.audioOutputDevice
         );

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -255,6 +255,27 @@
                   </q-tooltip>
                 </q-toggle>
               </q-card-actions>
+              <q-card-actions class="q-px-md q-py-none bg-setting-item">
+                <div>再生デバイス</div>
+                <q-space />
+                <q-select
+                  dense
+                  v-model="currentAudioOutputDeviceComputed"
+                  label="再生デバイス"
+                  :options="availableAudioOutputDevices"
+                  class="col-7"
+                >
+                  <q-tooltip
+                    :delay="500"
+                    anchor="center left"
+                    self="center right"
+                    transition-show="jump-left"
+                    transition-hide="jump-right"
+                  >
+                    音声の再生デバイスを変更し再生します
+                  </q-tooltip>
+                </q-select>
+              </q-card-actions>
               <!-- FIXME: バージョン0.8.0現在、エンジン側にサンプリングレート変更エラーがあるので機能制限 -->
               <!-- <q-card-actions class="q-px-md q-py-none bg-grey-3">
                 <div>音声のサンプリングレート</div>
@@ -324,7 +345,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, ref } from "vue";
 import { useStore } from "@/store";
 import { useQuasar } from "quasar";
 import { SavingSetting } from "@/type/preload";
@@ -374,6 +395,38 @@ export default defineComponent({
         return { label: theme.name, value: theme.name };
       });
     });
+
+    const currentAudioOutputDeviceComputed = computed({
+      get: () => {
+        const device = availableAudioOutputDevices.value?.find(
+          (device) => device.key === store.state.savingSetting.audioOutputDevice
+        );
+        if (device) {
+          return device.label;
+        } else {
+          handleSavingSettingChange("audioOutputDevice", "default");
+          return null;
+        }
+      },
+      set: (device: any) => {
+        handleSavingSettingChange("audioOutputDevice", device.key);
+      },
+    });
+
+    const availableAudioOutputDevices = ref<{ key: string; label: string }[]>();
+    const updateAudioOutputDevices = async () => {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      availableAudioOutputDevices.value = devices
+        .filter((device) => device.kind === "audiooutput")
+        .map((device) => {
+          return { label: device.label, key: device.deviceId };
+        });
+    };
+    navigator.mediaDevices.addEventListener(
+      "devicechange",
+      updateAudioOutputDevices
+    );
+    updateAudioOutputDevices();
 
     const changeUseGPU = async (useGpu: boolean) => {
       if (store.state.useGpu === useGpu) return;
@@ -492,6 +545,8 @@ export default defineComponent({
       settingDialogOpenedComputed,
       engineMode,
       inheritAudioInfoMode,
+      currentAudioOutputDeviceComputed,
+      availableAudioOutputDevices,
       changeinheritAudioInfo,
       restartEngineProcess,
       savingSetting,

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -401,6 +401,7 @@ export default defineComponent({
       label: string;
     } | null>({
       get: () => {
+        //見つからなかったらデフォルト値に戻す
         const device = availableAudioOutputDevices.value?.find(
           (device) => device.key === store.state.savingSetting.audioOutputDevice
         );

--- a/src/components/SettingDialog.vue
+++ b/src/components/SettingDialog.vue
@@ -272,7 +272,7 @@
                     transition-show="jump-left"
                     transition-hide="jump-right"
                   >
-                    音声の再生デバイスを変更し再生します
+                    音声の再生デバイスを変更し再生を行います
                   </q-tooltip>
                 </q-select>
               </q-card-actions>

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -840,6 +840,9 @@ export const audioStore: VoiceVoxStoreOptions<
         audioElem
           .setSinkId(state.savingSetting.audioOutputDevice)
           .catch((err) => {
+            audioElem.pause();
+            audioElem.currentTime = 0;
+
             window.electron.showErrorDialog({
               title: "エラー",
               message: "再生デバイスが見つかりません",
@@ -865,7 +868,9 @@ export const audioStore: VoiceVoxStoreOptions<
           commit("SET_AUDIO_NOW_PLAYING", { audioKey, nowPlaying: false });
         });
 
-        audioElem.play();
+        audioElem.play().catch((err) => {
+          throw new Error(err);
+        });
         return audioPlayPromise;
       }
     ),

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -815,7 +815,7 @@ export const audioStore: VoiceVoxStoreOptions<
         { audioKey }: { audioKey: string }
       ) => {
         const audioElem = audioElements[audioKey] as HTMLAudioElement & {
-          setSinkId(deviceID: string): void; // setSinkIdを認識してくれないため
+          setSinkId(deviceID: string): Promise<undefined>; // setSinkIdを認識してくれないため
         };
         audioElem.pause();
 
@@ -837,15 +837,15 @@ export const audioStore: VoiceVoxStoreOptions<
         }
         audioElem.src = URL.createObjectURL(blob);
 
-        navigator.mediaDevices.enumerateDevices().then((devices) => {
-          const device = devices.find(
-            (device) =>
-              device.deviceId === state.savingSetting.audioOutputDevice
-          );
-          if (device) {
-            audioElem.setSinkId(state.savingSetting.audioOutputDevice);
-          }
-        });
+        audioElem
+          .setSinkId(state.savingSetting.audioOutputDevice)
+          .catch((err) => {
+            window.electron.showErrorDialog({
+              title: "エラー",
+              message: "再生デバイスが見つかりません",
+            });
+            throw new Error(err);
+          });
 
         // 再生終了時にresolveされるPromiseを返す
         const played = async () => {

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -29,6 +29,7 @@ export const settingStoreState: SettingStoreState = {
     exportText: true,
     outputStereo: false,
     outputSamplingRate: 24000,
+    audioOutputDevice: "",
   },
   hotkeySettings: [],
   engineHost: process.env.VUE_APP_ENGINE_URL as unknown as string,

--- a/src/store/setting.ts
+++ b/src/store/setting.ts
@@ -29,7 +29,7 @@ export const settingStoreState: SettingStoreState = {
     exportText: true,
     outputStereo: false,
     outputSamplingRate: 24000,
-    audioOutputDevice: "",
+    audioOutputDevice: "default",
   },
   hotkeySettings: [],
   engineHost: process.env.VUE_APP_ENGINE_URL as unknown as string,

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -103,6 +103,7 @@ export type SavingSetting = {
   exportText: boolean;
   outputStereo: boolean;
   outputSamplingRate: number;
+  audioOutputDevice: string;
 };
 
 export type DefaultStyleId = {

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -42,7 +42,7 @@ describe("store/vuex.js test", () => {
           exportText: true,
           outputStereo: false,
           outputSamplingRate: 24000,
-          audioOutputDevice: "",
+          audioOutputDevice: "default",
         },
         themeSetting: {
           currentTheme: "Default",

--- a/tests/unit/store/Vuex.spec.ts
+++ b/tests/unit/store/Vuex.spec.ts
@@ -42,6 +42,7 @@ describe("store/vuex.js test", () => {
           exportText: true,
           outputStereo: false,
           outputSamplingRate: 24000,
+          audioOutputDevice: "",
         },
         themeSetting: {
           currentTheme: "Default",


### PR DESCRIPTION
## 内容
音声の再生デバイスを変更する設定を追加しました。
再生するたびに利用可能なデバイスを探索し、見つからなかった場合はデフォルトのまま再生します。

再生デバイスを変更するsetSinkIdという関数ががexperimentalな機能であるためか、
typescriptに(?)認識されておらず怒られてしまったため、変則的な方法で対応することになってしまいました。
Chromiumが対応してくれているので使用するのに問題は無いかと思いますが、
今後諸々のアップデートで対応されたり変更になったりしたら更新する必要があります。

<!--
プルリクエストの内容説明を端的に記載してください。
-->

## 関連 Issue
close #459
<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->

## スクリーンショット・動画など

![voicevox 2021_11_19 18_20_04](https://user-images.githubusercontent.com/91000720/142598082-798b8b3d-9b01-4e5e-a177-6287e167f3be.png)
![voicevox 2021_11_19 18_20_20](https://user-images.githubusercontent.com/91000720/142598112-4b86cff1-6517-48c4-ad2a-c6f19d3f9edd.png)

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
