### PR TITLE
Bump caniuse-lite from 1.0.3001228 to 1.0.3001282

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5610,9 +5610,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001282",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
+      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
       "dev": true
     },
     "case-sensitive-paths-webpack-plugin": {


### PR DESCRIPTION
## 内容

ビルド時に
```
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
```
が繰り返し出てるので、更新します。
