### PR TITLE
立ち絵の表示が狂う問題の修正

### DIFF
--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -60,25 +60,22 @@ $background: var(--color-background);
 .character-name {
   position: absolute;
   padding: 1px 24px 1px 8px;
-  background-image: linear-gradient(
-    90deg,
-    rgba($background, 0.5) 0%,
-    rgba($background, 0.5) 75%,
-    transparent 100%
-  );
+  //background-image: linear-gradient(
+  //  90deg,
+  //  rgba($background, 0.5) 0%,
+  //  rgba($background, 0.5) 75%,
+  //  transparent 100%
+  //);
 }
 
 .character-portrait-wrapper {
   display: grid;
-  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
   overflow: hidden;
   .character-portrait {
-    object-fit: none;
-    object-position: center top;
-    width: 100%;
-    height: fit-content;
+    margin: auto;
   }
 }
 </style>

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -55,17 +55,17 @@ export default defineComponent({
 </script>
 
 <style lang="scss" scoped>
-$background: var(--color-background);
+$background: var(--color-background-rgb);
 
 .character-name {
   position: absolute;
   padding: 1px 24px 1px 8px;
-  //background-image: linear-gradient(
-  //  90deg,
-  //  rgba($background, 0.5) 0%,
-  //  rgba($background, 0.5) 75%,
-  //  transparent 100%
-  //);
+  background-image: linear-gradient(
+    90deg,
+    rgba($background, 0.5) 0%,
+    rgba($background, 0.5) 75%,
+    transparent 100%
+  );
   overflow-wrap: anywhere;
 }
 

--- a/src/components/CharacterPortrait.vue
+++ b/src/components/CharacterPortrait.vue
@@ -66,6 +66,7 @@ $background: var(--color-background);
   //  rgba($background, 0.5) 75%,
   //  transparent 100%
   //);
+  overflow-wrap: anywhere;
 }
 
 .character-portrait-wrapper {


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
Electronのバージョンを上げたことで、立ち絵のCSSが正しく適用されていない問題を修正しました。
~~現状は、元のものとほとんど同じ動作をします。~~ 元のものと全く同じ動作をしているはずです...!

~~ただし、名前の部分で`rgba($background, 0.5)`の表記が無効になった(逆に何故今まで使えていたかがわからない)ので、そこだけコメントアウトしています。
この表記が使える状態にするには、テーマを定義しているjsonを書き換える必要があります(そこまではやっていません)。~~
<!-- before
```
  "colors": {
    "primary": "#A5D4AD",
    "primary-light": "#A5D4AD",
    "display": "#121212",
    "display-light": "#EBEBEB",
    "display-dark": "#121212",
    "background": "#FFFFFF",
    "background-light": "#FFFFFF",
    "setting-item": "#EEEEEE",
    "warning": "#C10015",
    "markdown-color": "#24292F",
    "markdown-background": "#FFFFFF",
    "markdown-hyperlink": "#0969DA",
    "pause-hovered": "#CCDDFF"
  }
```
after
```
  "colors": {
    "primary": "165, 212, 173",
    "primary-light": "165, 212, 173",
    "display": "18, 18, 18",
    "display-light": "235, 235, 235",
    "display-dark": "18, 18, 18",
    "background": "255, 255, 255",
    "background-light": "255, 255, 255",
    "setting-item": "238, 238, 238",
    "warning": "193, 0, 21",
    "markdown-color": "36, 41, 47",
    "markdown-background": "255, 255, 255",
    "markdown-hyperlink": "9, 105, 218",
    "pause-hovered": "204, 221, 255)"
  }
``` -->
コメントで頂いたrgb化のもののおかげで、json変更の必要がなくなりました！
@MT224244 さん、機能実装・助言ありがとうございます！

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #499
