### PR TITLE
エンジン(再)起動時の色を修正

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -490,7 +490,7 @@ body {
 }
 
 .waiting-engine {
-  background-color: var(--color-background);
+  background-color: rgba(var(--color-display-dark-rgb), 0.15);
   position: absolute;
   inset: 0;
   z-index: 10;


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
題の通り
元の色は`#0002`だったのですが、若干変更しました。
ダークテーマ時は全然透かしにならないので、ちょっと工夫が必要かもしれません。
AudioCellが非表示になってしまっているように見えるのは、単純に白塗りになっていたからみたいです。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
close #504

## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->
![image](https://user-images.githubusercontent.com/34832037/142885838-4dac8c86-21c5-4115-9b41-f7a15c59d67a.png)

