### PR TITLE
スタイルのないキャラのためのUI・機能修正

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -684,7 +684,7 @@ ipcMainHandle("CHANGE_PIN_WINDOW", () => {
 
 ipcMainHandle("IS_UNSET_DEFAULT_STYLE_ID", (_, speakerUuid) => {
   const defaultStyleIds = store.get("defaultStyleIds");
-  return !!defaultStyleIds.find((style) => style.speakerUuid === speakerUuid);
+  return !defaultStyleIds.find((style) => style.speakerUuid === speakerUuid);
 });
 
 ipcMainHandle("GET_DEFAULT_STYLE_IDS", () => {

--- a/src/background.ts
+++ b/src/background.ts
@@ -682,8 +682,9 @@ ipcMainHandle("CHANGE_PIN_WINDOW", () => {
   }
 });
 
-ipcMainHandle("IS_UNSET_DEFAULT_STYLE_IDS", () => {
-  return store.get("defaultStyleIds").length === 0;
+ipcMainHandle("IS_UNSET_DEFAULT_STYLE_ID", (_, speakerUuid) => {
+  const defaultStyleIds = store.get("defaultStyleIds");
+  return !!defaultStyleIds.find((style) => style.speakerUuid === speakerUuid);
 });
 
 ipcMainHandle("GET_DEFAULT_STYLE_IDS", () => {

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -53,57 +53,66 @@
                 <div>{{ characterInfo.metas.speakerName }}</div>
               </q-btn>
 
-              <q-separator vertical />
+              <template v-if="characterInfo.metas.styles.length > 1">
+                <q-separator vertical />
 
-              <div
-                class="flex items-center q-px-sm q-py-none cursor-pointer"
-                :class="
-                  subMenuOpenFlags[characterIndex] && 'opened-character-item'
-                "
-                @mouseover="reassignSubMenuOpen(characterIndex)"
-                @mouseleave="reassignSubMenuOpen.cancel()"
-              >
-                <q-icon name="keyboard_arrow_right" color="grey-6" size="sm" />
-
-                <q-menu
-                  no-parent-event
-                  anchor="top end"
-                  self="top start"
-                  transition-show="none"
-                  transition-hide="none"
-                  class="character-menu"
-                  v-model="subMenuOpenFlags[characterIndex]"
+                <div
+                  class="flex items-center q-px-sm q-py-none cursor-pointer"
+                  :class="
+                    subMenuOpenFlags[characterIndex] && 'opened-character-item'
+                  "
+                  @mouseover="reassignSubMenuOpen(characterIndex)"
+                  @mouseleave="reassignSubMenuOpen.cancel()"
                 >
-                  <q-list>
-                    <q-item
-                      v-for="(style, styleIndex) in characterInfo.metas.styles"
-                      :key="styleIndex"
-                      clickable
-                      v-close-popup
-                      active-class="selected-character-item"
-                      :active="style.styleId === selectedStyle.styleId"
-                      @click="changeStyleId(style.styleId)"
-                    >
-                      <q-avatar rounded size="2rem" class="q-mr-md">
-                        <q-img
-                          no-spinner
-                          no-transition
-                          :ratio="1"
-                          :src="characterInfo.metas.styles[styleIndex].iconPath"
-                        />
-                      </q-avatar>
-                      <q-item-section v-if="style.styleName"
-                        >{{ characterInfo.metas.speakerName }} ({{
-                          style.styleName
-                        }})</q-item-section
+                  <q-icon
+                    name="keyboard_arrow_right"
+                    color="grey-6"
+                    size="sm"
+                  />
+
+                  <q-menu
+                    no-parent-event
+                    anchor="top end"
+                    self="top start"
+                    transition-show="none"
+                    transition-hide="none"
+                    class="character-menu"
+                    v-model="subMenuOpenFlags[characterIndex]"
+                  >
+                    <q-list>
+                      <q-item
+                        v-for="(style, styleIndex) in characterInfo.metas
+                          .styles"
+                        :key="styleIndex"
+                        clickable
+                        v-close-popup
+                        active-class="selected-character-item"
+                        :active="style.styleId === selectedStyle.styleId"
+                        @click="changeStyleId(style.styleId)"
                       >
-                      <q-item-section v-else>{{
-                        characterInfo.metas.speakerName
-                      }}</q-item-section>
-                    </q-item>
-                  </q-list>
-                </q-menu>
-              </div>
+                        <q-avatar rounded size="2rem" class="q-mr-md">
+                          <q-img
+                            no-spinner
+                            no-transition
+                            :ratio="1"
+                            :src="
+                              characterInfo.metas.styles[styleIndex].iconPath
+                            "
+                          />
+                        </q-avatar>
+                        <q-item-section v-if="style.styleName"
+                          >{{ characterInfo.metas.speakerName }} ({{
+                            style.styleName
+                          }})</q-item-section
+                        >
+                        <q-item-section v-else>{{
+                          characterInfo.metas.speakerName
+                        }}</q-item-section>
+                      </q-item>
+                    </q-list>
+                  </q-menu>
+                </div>
+              </template>
             </q-btn-group>
           </q-item>
         </q-list>

--- a/src/components/AudioCell.vue
+++ b/src/components/AudioCell.vue
@@ -53,7 +53,8 @@
                 <div>{{ characterInfo.metas.speakerName }}</div>
               </q-btn>
 
-              <template v-if="characterInfo.metas.styles.length > 1">
+              <!-- スタイルが2つ以上あるものだけ、スタイル選択ボタンを表示する-->
+              <template v-if="characterInfo.metas.styles.length >= 2">
                 <q-separator vertical />
 
                 <div

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -362,15 +362,12 @@ export default defineComponent({
 }
 .character-portrait-wrapper {
   display: grid;
-  align-items: center;
+  justify-content: center;
   width: 100%;
   height: 100%;
   overflow: hidden;
   .character-portrait {
-    object-fit: none;
-    object-position: center top;
-    width: 100%;
-    height: fit-content;
+    margin: auto;
   }
 }
 .q-tab-panels {

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -11,15 +11,26 @@
       <q-header class="q-py-sm">
         <q-toolbar>
           <div class="column">
-            <q-toolbar-title v-if="isFirstTime" class="text-display text-h6"
-              >「{{
-                characterInfos[pageIndex].metas.speakerName
-              }}」のデフォルトのスタイル（喋り方）を選んでください</q-toolbar-title
-            >
+            <q-toolbar-title
+              v-if="isFirstTime && showCharacterInfos.length > 0"
+              class="text-display text-h6"
+              >「{{ showCharacterInfos[pageIndex].metas.speakerName }}」の{{
+                showCharacterInfos[pageIndex].metas.styles.length > 1
+                  ? "デフォルトのスタイル（喋り方）を選んでください"
+                  : "サンプル音声を視聴できます"
+              }}
+            </q-toolbar-title>
             <q-toolbar-title v-else class="text-display"
-              >設定 / デフォルトスタイル</q-toolbar-title
+              >設定 / デフォルトスタイル・試聴</q-toolbar-title
             >
-            <span v-if="isFirstTime" class="text-display text-caption q-ml-sm">
+            <span
+              v-if="
+                isFirstTime &&
+                showCharacterInfos.length > 0 &&
+                showCharacterInfos[pageIndex].metas.styles.length > 1
+              "
+              class="text-display text-caption q-ml-sm"
+            >
               ※後からでも変更できます
             </span>
           </div>
@@ -38,11 +49,11 @@
             />
 
             <div class="text-subtitle2 text-no-wrap text-display q-mr-md">
-              {{ pageIndex + 1 }} / {{ characterInfos.length }}
+              {{ pageIndex + 1 }} / {{ showCharacterInfos.length }}
             </div>
 
             <q-btn
-              v-if="pageIndex + 1 < characterInfos.length"
+              v-if="pageIndex + 1 < showCharacterInfos.length"
               unelevated
               label="次へ"
               color="background-light"
@@ -74,17 +85,18 @@
       >
         <div class="character-portrait-wrapper">
           <img
-            :src="characterInfos[pageIndex].portraitPath"
+            v-if="showCharacterInfos.length > 0"
+            :src="showCharacterInfos[pageIndex].portraitPath"
             class="character-portrait"
           />
         </div>
       </q-drawer>
 
       <q-page-container>
-        <q-page v-if="characterInfos && selectedStyleIndexes">
+        <q-page v-if="showCharacterInfos && selectedStyleIndexes">
           <q-tab-panels v-model="pageIndex">
             <q-tab-panel
-              v-for="(characterInfo, characterIndex) of characterInfos"
+              v-for="(characterInfo, characterIndex) of showCharacterInfos"
               :key="characterIndex"
               :name="characterIndex"
             >
@@ -163,7 +175,7 @@
 <script lang="ts">
 import { defineComponent, computed, ref, PropType, watch } from "vue";
 import { useStore } from "@/store";
-import { CharacterInfo, StyleInfo } from "@/type/preload";
+import { CharacterInfo, DefaultStyleId, StyleInfo } from "@/type/preload";
 
 export default defineComponent({
   name: "DefaultStyleSelectDialog",
@@ -187,6 +199,10 @@ export default defineComponent({
       set: (val) => emit("update:modelValue", val),
     });
 
+    // アップデートで増えたキャラ・スタイルがあれば、それらに対して起動時にデフォルトスタイル選択・試聴を問うための変数
+    // その他の場合は、characterInfosと同じになる
+    const showCharacterInfos = ref(props.characterInfos);
+
     const isFirstTime = ref(false);
     const selectedStyleIndexes = ref<(number | undefined)[]>([]);
 
@@ -195,6 +211,7 @@ export default defineComponent({
       () => props.modelValue,
       async (newValue, oldValue) => {
         if (!oldValue && newValue) {
+          showCharacterInfos.value = [];
           selectedStyleIndexes.value = await Promise.all(
             props.characterInfos.map(async (info) => {
               const styles = info.metas.styles;
@@ -204,6 +221,7 @@ export default defineComponent({
               );
               if (isUnsetDefaultStyleId) {
                 isFirstTime.value = true;
+                showCharacterInfos.value.push(info);
                 return undefined;
               }
 
@@ -217,6 +235,19 @@ export default defineComponent({
               return index === -1 ? undefined : index;
             })
           );
+          if (!isFirstTime.value) {
+            showCharacterInfos.value = props.characterInfos;
+          } else {
+            selectedStyleIndexes.value = showCharacterInfos.value.map(
+              (info) => {
+                if (info.metas.styles.length > 1) {
+                  return undefined;
+                } else {
+                  return info.metas.styles[0].styleId;
+                }
+              }
+            );
+          }
         }
       }
     );
@@ -226,7 +257,7 @@ export default defineComponent({
 
       // 音声を再生する。同じstyleIndexだったら停止する。
       const selectedStyleInfo =
-        props.characterInfos[characterIndex].metas.styles[styleIndex];
+        showCharacterInfos.value[characterIndex].metas.styles[styleIndex];
       if (
         playing.value !== undefined &&
         playing.value.styleId === selectedStyleInfo.styleId
@@ -277,12 +308,26 @@ export default defineComponent({
     };
 
     const closeDialog = () => {
-      const defaultStyleIds = props.characterInfos.map((info, idx) => ({
-        speakerUuid: info.metas.speakerUuid,
-        defaultStyleId:
-          info.metas.styles[selectedStyleIndexes.value[idx] ?? 0].styleId,
-      }));
+      const defaultStyleIds = JSON.parse(
+        JSON.stringify(store.state.defaultStyleIds)
+      ) as DefaultStyleId[];
+      showCharacterInfos.value.forEach((info, idx) => {
+        const defaultStyleInfo = {
+          speakerUuid: info.metas.speakerUuid,
+          defaultStyleId:
+            info.metas.styles[selectedStyleIndexes.value[idx] ?? 0].styleId,
+        };
+        const nowSettingIndex = defaultStyleIds.findIndex(
+          (s) => s.speakerUuid === info.metas.speakerUuid
+        );
+        if (nowSettingIndex !== -1) {
+          defaultStyleIds[nowSettingIndex] = defaultStyleInfo;
+        } else {
+          defaultStyleIds.push(defaultStyleInfo);
+        }
+      });
       store.dispatch("SET_DEFAULT_STYLE_IDS", defaultStyleIds);
+      isFirstTime.value = false;
 
       stop();
       modelValueComputed.value = false;
@@ -291,6 +336,7 @@ export default defineComponent({
 
     return {
       modelValueComputed,
+      showCharacterInfos,
       isFirstTime,
       selectedStyleIndexes,
       selectStyleIndex,

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -308,6 +308,7 @@ export default defineComponent({
       pageIndex.value++;
     };
 
+    // 既に設定が存在する場合があるので、新しい設定と既存設定を合成させる
     const closeDialog = () => {
       const defaultStyleIds = JSON.parse(
         JSON.stringify(store.state.defaultStyleIds)

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -201,6 +201,7 @@ export default defineComponent({
 
     // アップデートで増えたキャラ・スタイルがあれば、それらに対して起動時にデフォルトスタイル選択・試聴を問うための変数
     // その他の場合は、characterInfosと同じになる
+    // FIXME: 現状はスタイルが増えてもデフォルトスタイルを問えないので、そこを改修しなければならない
     const showCharacterInfos = ref(props.characterInfos);
 
     const isFirstTime = ref(false);

--- a/src/components/DefaultStyleSelectDialog.vue
+++ b/src/components/DefaultStyleSelectDialog.vue
@@ -202,7 +202,7 @@ export default defineComponent({
                 "IS_UNSET_DEFAULT_STYLE_ID",
                 { speakerUuid: info.metas.speakerUuid }
               );
-              if (!isUnsetDefaultStyleId) {
+              if (isUnsetDefaultStyleId) {
                 isFirstTime.value = true;
                 return undefined;
               }

--- a/src/components/MenuBar.vue
+++ b/src/components/MenuBar.vue
@@ -310,7 +310,7 @@ export default defineComponent({
           },
           {
             type: "button",
-            label: "デフォルトスタイル",
+            label: "デフォルトスタイル・試聴",
             onClick() {
               store.dispatch("IS_DEFAULT_STYLE_SELECT_DIALOG_OPEN", {
                 isDefaultStyleSelectDialogOpen: true,

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -184,8 +184,8 @@ const api: Sandbox = {
     return ipcRenderer.invoke("HOTKEY_SETTINGS", { newData });
   },
 
-  isUnsetDefaultStyleIds: async () => {
-    return await ipcRendererInvoke("IS_UNSET_DEFAULT_STYLE_IDS");
+  isUnsetDefaultStyleId: async (speakerUuid: string) => {
+    return await ipcRendererInvoke("IS_UNSET_DEFAULT_STYLE_ID", speakerUuid);
   },
 
   getDefaultStyleIds: async () => {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -92,8 +92,8 @@ export const indexStore: VoiceVoxStoreOptions<
     LOG_INFO(_, ...params: unknown[]) {
       window.electron.logInfo(...params);
     },
-    async IS_UNSET_DEFAULT_STYLE_IDS() {
-      return await window.electron.isUnsetDefaultStyleIds();
+    async IS_UNSET_DEFAULT_STYLE_ID(_, { speakerUuid }) {
+      return await window.electron.isUnsetDefaultStyleId(speakerUuid);
     },
     async LOAD_DEFAULT_STYLE_IDS({ commit }) {
       const defaultStyleIds = await window.electron.getDefaultStyleIds();

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -525,8 +525,8 @@ type IndexStoreTypes = {
     action(): Promise<string>;
   };
 
-  IS_UNSET_DEFAULT_STYLE_IDS: {
-    action(): Promise<boolean>;
+  IS_UNSET_DEFAULT_STYLE_ID: {
+    action(payload: { speakerUuid: string }): Promise<boolean>;
   };
 
   LOAD_DEFAULT_STYLE_IDS: {

--- a/src/type/ipc.d.ts
+++ b/src/type/ipc.d.ts
@@ -152,8 +152,8 @@ type IpcIHData = {
     return: import("@/type/preload").HotkeySetting[];
   };
 
-  IS_UNSET_DEFAULT_STYLE_IDS: {
-    args: [];
+  IS_UNSET_DEFAULT_STYLE_ID: {
+    args: [speakerUuid: string];
     return: boolean;
   };
 

--- a/src/type/preload.d.ts
+++ b/src/type/preload.d.ts
@@ -52,7 +52,7 @@ export interface Sandbox {
   hotkeySettings(newData?: HotkeySetting): Promise<HotkeySetting[]>;
   checkFileExists(file: string): Promise<boolean>;
   changePinWindow(): void;
-  isUnsetDefaultStyleIds(): Promise<boolean>;
+  isUnsetDefaultStyleId(speakerUuid: string): Promise<boolean>;
   getDefaultStyleIds(): Promise<DefaultStyleId[]>;
   setDefaultStyleIds(
     defaultStyleIds: { speakerUuid: string; defaultStyleId: number }[]

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -356,13 +356,12 @@ export default defineComponent({
         store.dispatch("LOAD_DEFAULT_STYLE_IDS"),
       ]);
       let isUnsetDefaultStyleIds = false;
-      if (characterInfos.value) {
-        for (const info of characterInfos.value) {
-          isUnsetDefaultStyleIds ||= await store.dispatch(
-            "IS_UNSET_DEFAULT_STYLE_ID",
-            { speakerUuid: info.metas.speakerUuid }
-          );
-        }
+      if (characterInfos.value == undefined) throw new Error();
+      for (const info of characterInfos.value) {
+        isUnsetDefaultStyleIds ||= await store.dispatch(
+          "IS_UNSET_DEFAULT_STYLE_ID",
+          { speakerUuid: info.metas.speakerUuid }
+        );
       }
       isDefaultStyleSelectDialogOpenComputed.value = isUnsetDefaultStyleIds;
       const audioItem: AudioItem = await store.dispatch(

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -355,9 +355,16 @@ export default defineComponent({
         store.dispatch("LOAD_CHARACTER"),
         store.dispatch("LOAD_DEFAULT_STYLE_IDS"),
       ]);
-      if (await store.dispatch("IS_UNSET_DEFAULT_STYLE_IDS")) {
-        isDefaultStyleSelectDialogOpenComputed.value = true;
+      let isUnsetDefaultStyleIds = false;
+      if (characterInfos.value) {
+        for (const info of characterInfos.value) {
+          isUnsetDefaultStyleIds &&= await store.dispatch(
+            "IS_UNSET_DEFAULT_STYLE_ID",
+            { speakerUuid: info.metas.speakerUuid }
+          );
+        }
       }
+      isDefaultStyleSelectDialogOpenComputed.value = !isUnsetDefaultStyleIds;
       const audioItem: AudioItem = await store.dispatch(
         "GENERATE_AUDIO_ITEM",
         {}

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -358,13 +358,13 @@ export default defineComponent({
       let isUnsetDefaultStyleIds = false;
       if (characterInfos.value) {
         for (const info of characterInfos.value) {
-          isUnsetDefaultStyleIds &&= await store.dispatch(
+          isUnsetDefaultStyleIds ||= await store.dispatch(
             "IS_UNSET_DEFAULT_STYLE_ID",
             { speakerUuid: info.metas.speakerUuid }
           );
         }
       }
-      isDefaultStyleSelectDialogOpenComputed.value = !isUnsetDefaultStyleIds;
+      isDefaultStyleSelectDialogOpenComputed.value = isUnsetDefaultStyleIds;
       const audioItem: AudioItem = await store.dispatch(
         "GENERATE_AUDIO_ITEM",
         {}


### PR DESCRIPTION
## 内容

<!--
プルリクエストの内容説明を端的に記載してください。
-->
- #509 での問題である、`IS_UNSET_DEFAULT_STYLE_IDS`などをリファクタリングし、`IS_UNSET_DEFAULT_STYLE_ID`に改名したうえで、speaker uuidを引数として各話者ごとにデフォルトスタイルがセットされているか否かを取得できるようにしました。
また、その改変に伴って必要な周辺の修正も行いました。
- これによって、新規キャラが増えた際に、再度デフォルトスタイルについて問うようになります。
- 加えて、非常に内容が近しい #501 のために以下の修正を行いました。
  - スタイルのないキャラにおいてはスタイル選択画面で「試聴ができる」ことを表すような文言を表示するように変更
  - これに伴い、メニュー名を「デフォルトスタイル・試聴」に変更
    - 別にこれである必要はない気がするので、元に戻しても良さそうです。
  - 新規キャラが増えた際、起動時にそのキャラに対してのみデフォルトスタイルを問うようにしました。
    - ただし、既存キャラのスタイルが増えても、そこに関しては問い直せないのが、現状の問題です。
  - スタイルが一つしかないキャラに関して、キャラ選択UIを改善しました。
    - ![image](https://user-images.githubusercontent.com/34832037/143505943-d3fdc2ac-2338-4c97-99a4-8aa1142fe825.png)
- また、#501 や #509 とは関係ないですが、デフォルトスタイルを選択できる画面において、立ち絵が崩れる問題を修正しました。

## 関連 Issue

<!--
関連するIssue番号を記載してください。
番号の前に"close"を書くと自動的にIssueが閉じられます。

（例）
ref #0
close #0
-->
- close #501 
- close #509 


## スクリーンショット・動画など

<!--
UIを変更した際は、変更がわかるような動画・スクリーンショットがあると助かります。
-->

## その他
デフォルトスタイルを聞かれている時に、メニューバーからほかのものにアクセスできる状況を何とかしたいですね...
