### PR TITLE
開発時はelectron-storeの保存先を変更する

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -140,6 +140,7 @@ const store = new Store<{
   defaultStyleIds: DefaultStyleId[];
   currentTheme: string;
 }>({
+  name: isDevelopment ? "config-dev" : undefined,
   schema: {
     useGpu: {
       type: "boolean",


### PR DESCRIPTION
## 内容

リリース版と開発版で同じ設定ファイルを参照していると意図しない挙動をすることがあるため、開発時のみ別名で保存するようにします
