### PR TITLE
テスト時にmock版エンジンを動かしてみる

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  VOICEVOX_ENGINE_REPO: "VOICEVOX/voicevox_nemo_engine" # 軽いのでNemoを使う
-  VOICEVOX_ENGINE_VERSION: "0.14.0"
+  VOICEVOX_ENGINE_REPO: "VOICEVOX/voicevox_engine"
+  VOICEVOX_ENGINE_COMMIT_HASH: "346e1f7333fd5fdb5c43902e92bf2ac3f082ea1f"
 
 defaults:
   run:
@@ -85,31 +85,33 @@ jobs:
           sudo apt-get install -y xvfb x11-xserver-utils # for electron
           sudo apt-get install -y libsndfile1 # for engine
 
-      - name: Download VOICEVOX ENGINE
-        id: download-engine
-        uses: ./.github/actions/download-engine
-        with:
-          repo: ${{ env.VOICEVOX_ENGINE_REPO }}
-          version: ${{ env.VOICEVOX_ENGINE_VERSION }}
-          dest: ${{ github.workspace }}/voicevox_engine
-          target: ${{ matrix.voicevox_engine_asset_name }}
-
       - name: Setup
         run: |
           # playwright
           npx playwright install
 
-          # run.exe
-          chmod +x ${{ steps.download-engine.outputs.run_path }}
-
           # .env
           sed -i -e 's|"074fc39e-678b-4c13-8916-ffca8d505d1d"|"208cf94d-43d2-4cf5-abc0-9783cac36d29"|' .env.test
-          sed -i -e 's|"../voicevox_engine/run.exe"|"${{ steps.download-engine.outputs.run_path }}"|' .env.test
+          sed -i -e 's|"executionEnabled": \[\],|"executionEnabled": false,|' .env.test
           # GitHub Actions 環境だとたまに50021が封じられていることがあるので、ランダムなポートを使うようにする
           PORT=$(node -r net -e "server=net.createServer();server.listen(0,()=>{console.log(server.address().port);server.close()})")
           sed -i -e 's|"host": "http://127.0.0.1:50021"|"host": "http://127.0.0.1:'$PORT'"|' .env.test
           sed -i -e 's|"executionArgs": \[\],|"executionArgs": ["--port='$PORT'"],|' .env.test
           cp .env.test .env
+
+          # mock版エンジンのダウンロード
+          if [ ! -d /tmp/voicevox_engine ]; then
+            curl -L "https://github.com/${{ env.VOICEVOX_ENGINE_REPO }}/archive/${{ env.VOICEVOX_ENGINE_COMMIT_HASH }}.zip" -o /tmp/voicevox_engine.zip
+            7z x /tmp/voicevox_engine.zip -o/tmp
+            mv /tmp/voicevox_engine-${{ env.VOICEVOX_ENGINE_COMMIT_HASH }} /tmp/voicevox_engine
+            rm /tmp/voicevox_engine.zip
+          fi
+
+          # mock版エンジンの起動
+          cd /tmp/voicevox_engine
+          pip install -r requirements-dev.txt
+          python run.py --enable_mock --port $PORT &
+          cd -
 
       - name: Run npm run test:browser-e2e
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11.3
-          cache: pip
 
       - name: Install xvfb and x11-xserver-utils
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Setup
         run: |
+          set -eu
+
           # playwright
           npx playwright install
 
@@ -109,7 +111,7 @@ jobs:
 
           # mock版エンジンの起動
           cd /tmp/voicevox_engine
-          pip install -r requirements-dev.txt
+          pip install -r requirements.txt -r requirements-dev.txt
           python run.py --enable_mock --port $PORT &
           cd -
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.11.3
+          # キャッシュ効かせるためには先にrequirements.txtが必要
+          # ここのインストールのせいで余計に時間がかかる
+          # まあでも正直かなり微妙だった。これだったらモックで歌手返すだけで良い気もする。
 
       - name: Install xvfb and x11-xserver-utils
         if: startsWith(matrix.os, 'ubuntu')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
 
           # .env
           sed -i -e 's|"074fc39e-678b-4c13-8916-ffca8d505d1d"|"208cf94d-43d2-4cf5-abc0-9783cac36d29"|' .env.test
-          sed -i -e 's|"executionEnabled": \[\],|"executionEnabled": false,|' .env.test
+          sed -i -e 's|"executionEnabled": true,|"executionEnabled": false,|' .env.test
           # GitHub Actions 環境だとたまに50021が封じられていることがあるので、ランダムなポートを使うようにする
           PORT=$(node -r net -e "server=net.createServer();server.listen(0,()=>{console.log(server.address().port);server.close()})")
           sed -i -e 's|"host": "http://127.0.0.1:50021"|"host": "http://127.0.0.1:'$PORT'"|' .env.test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-environment
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11.3
+          cache: pip
+
       - name: Install xvfb and x11-xserver-utils
         if: startsWith(matrix.os, 'ubuntu')
         run: |


### PR DESCRIPTION
微妙だった。

Nemoのダウンロードはかなり速い。エンジン起動もそんなに重いようには感じない。
落ちやすいテストが落ちにくくなってるかもしれないけどそこは確認してない。

Pythonのセットアップとpip installが必要で、これを真面目にやると遅い。
しかもテストは別に早くならない。

Nemoにはない歌手を使ったテストとか、API更新したあとのを使うテストは簡単かもしれない。
けどまあ、mock APIを作れば良い気もする。