### PR TITLE
AccentPhrase全てにidを振ろうとした

### DIFF
--- a/src/components/Dialog/DictionaryManageDialog.vue
+++ b/src/components/Dialog/DictionaryManageDialog.vue
@@ -253,8 +253,8 @@ import { computed, ref, watch } from "vue";
 import { QInput } from "quasar";
 import AudioAccent from "@/components/Talk/AudioAccent.vue";
 import { useStore } from "@/store";
-import type { FetchAudioResult } from "@/store/type";
-import { AccentPhrase, UserDictWord } from "@/openapi";
+import type { EditorAccentPhrase, FetchAudioResult } from "@/store/type";
+import { UserDictWord } from "@/openapi";
 import {
   convertHiraToKana,
   convertLongVowel,
@@ -360,7 +360,7 @@ const voiceComputed = computed(() => {
 
 const kanaRegex = createKanaRegex();
 const isOnlyHiraOrKana = ref(true);
-const accentPhrase = ref<AccentPhrase | undefined>();
+const accentPhrase = ref<EditorAccentPhrase | undefined>();
 const accentPhraseTable = ref<HTMLElement>();
 
 const convertHankakuToZenkaku = (text: string) => {

--- a/src/components/Talk/AudioDetail.vue
+++ b/src/components/Talk/AudioDetail.vue
@@ -60,7 +60,7 @@
         </ToolTip>
         <AccentPhrase
           v-for="(accentPhrase, accentPhraseIndex) in accentPhrases"
-          :key="accentPhraseIndex"
+          :key="accentPhrase.editorID"
           ref="accentPhraseComponents"
           :audio-key="activeAudioKey"
           :accent-phrase="accentPhrase"
@@ -234,6 +234,9 @@ const setPlayAndStartPoint = (accentPhraseIndex: number) => {
 };
 
 watch(accentPhrases, async () => {
+  await store.dispatch("SET_ACCENT_PHRASES_EDITORID", {
+    audioKey: props.activeAudioKey,
+  });
   activePoint.value = startPoint.value;
   // 連続再生時に、最初に選択されていた場所に戻るためにscrollToActivePointを呼ぶ必要があるが、
   // DOMの描画が少し遅いので、nextTickをはさむ

--- a/src/components/Talk/AudioDetail.vue
+++ b/src/components/Talk/AudioDetail.vue
@@ -60,7 +60,7 @@
         </ToolTip>
         <AccentPhrase
           v-for="(accentPhrase, accentPhraseIndex) in accentPhrases"
-          :key="accentPhrase.editorID"
+          :key="accentPhrase.key"
           ref="accentPhraseComponents"
           :audio-key="activeAudioKey"
           :accent-phrase="accentPhrase"
@@ -234,9 +234,6 @@ const setPlayAndStartPoint = (accentPhraseIndex: number) => {
 };
 
 watch(accentPhrases, async () => {
-  await store.dispatch("SET_ACCENT_PHRASES_EDITORID", {
-    audioKey: props.activeAudioKey,
-  });
   activePoint.value = startPoint.value;
   // 連続再生時に、最初に選択されていた場所に戻るためにscrollToActivePointを呼ぶ必要があるが、
   // DOMの描画が少し遅いので、nextTickをはさむ

--- a/src/store/audio.ts
+++ b/src/store/audio.ts
@@ -1012,6 +1012,26 @@ export const audioStore = createPartialStore<AudioStoreTypes>({
       query.accentPhrases.splice(accentPhraseIndex, 1, ...accentPhrases);
     },
   },
+  SET_ACCENT_PHRASES_EDITORID: {
+    mutation(
+      state,
+      {
+        audioKey,
+      }: {
+        audioKey: AudioKey;
+      }
+    ) {
+      const accentPhrases = state.audioItems[audioKey].query?.accentPhrases;
+      if (accentPhrases)
+        accentPhrases.map((elem) => {
+          if (!elem.editorID)
+            elem.editorID = uuidv4();
+        });
+    },
+    action({ commit }, { audioKey }: { audioKey: AudioKey }) {
+      commit("SET_ACCENT_PHRASES_EDITORID", { audioKey });
+    },
+  },
 
   SET_AUDIO_MORA_DATA: {
     mutation(

--- a/src/store/project.ts
+++ b/src/store/project.ts
@@ -16,6 +16,7 @@ import {
 
 import { AccentPhrase } from "@/openapi";
 import {
+  accentPhraseKeySchema,
   audioKeySchema,
   EngineId,
   engineIdSchema,
@@ -656,6 +657,7 @@ const moraSchema = z.object({
 });
 
 const accentPhraseSchema = z.object({
+  key: accentPhraseKeySchema,
   moras: z.array(moraSchema),
   accent: z.number(),
   pauseMora: moraSchema.optional(),

--- a/src/store/proxy.ts
+++ b/src/store/proxy.ts
@@ -1,11 +1,17 @@
-import { ProxyStoreState, ProxyStoreTypes, EditorAudioQuery } from "./type";
+import { v4 as uuidv4 } from "uuid";
+import {
+  ProxyStoreState,
+  ProxyStoreTypes,
+  EditorAudioQuery,
+  EditorAccentPhrase,
+} from "./type";
 import { createPartialStore } from "./vuex";
 import {
   IEngineConnectorFactory,
   OpenAPIEngineConnectorFactory,
 } from "@/infrastructures/EngineConnector";
-import { AudioQuery } from "@/openapi";
-import { EngineInfo } from "@/type/preload";
+import { AccentPhrase, AudioQuery } from "@/openapi";
+import { AccentPhraseKey, EngineInfo } from "@/type/preload";
 
 export const proxyStoreState: ProxyStoreState = {};
 
@@ -35,6 +41,7 @@ const proxyStoreCreator = (_engineFactory: IEngineConnectorFactory) => {
   return proxyStore;
 };
 
+/** EditorAudioQueryをAudioQueryに変換する */
 export const convertAudioQueryFromEditorToEngine = (
   editorAudioQuery: EditorAudioQuery,
   defaultOutputSamplingRate: number
@@ -47,5 +54,34 @@ export const convertAudioQueryFromEditorToEngine = (
         : editorAudioQuery.outputSamplingRate,
   };
 };
+
+/** AudioQueryをEditorAudioQueryに変換する */
+export const convertAudioQueryFromEngineToEditor = (
+  audioQuery: AudioQuery
+): EditorAudioQuery => {
+  return {
+    ...audioQuery,
+    accentPhrases: audioQuery.accentPhrases.map((accentPhrase) =>
+      convertAccentPhraseFromEngineToEditor(accentPhrase)
+    ),
+    outputSamplingRate:
+      audioQuery.outputSamplingRate == undefined
+        ? "engineDefault"
+        : audioQuery.outputSamplingRate,
+  };
+};
+
+/** AccentPhraseをEditorAccentPhraseに変換する */
+export const convertAccentPhraseFromEngineToEditor = (
+  accentPhrase: AccentPhrase
+): EditorAccentPhrase => {
+  return {
+    key: generateAccentPhraseKey(),
+    ...accentPhrase,
+  };
+};
+function generateAccentPhraseKey() {
+  return AccentPhraseKey(uuidv4());
+}
 
 export const proxyStore = proxyStoreCreator(OpenAPIEngineConnectorFactory);

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -64,8 +64,12 @@ import { OverlappingNoteInfos } from "@/sing/storeHelper";
 /**
  * エディタ用のAudioQuery
  */
-export type EditorAudioQuery = Omit<AudioQuery, "outputSamplingRate"> & {
+export type EditorAudioQuery = Omit<
+  AudioQuery,
+  "outputSamplingRate" | "accentPhrases"
+> & {
   outputSamplingRate: number | "engineDefault";
+  accentPhrases: Array<EditorAccentPhrase>;
 };
 
 export type AudioItem = {
@@ -125,6 +129,9 @@ export type StoreType<T, U extends "getter" | "mutation" | "action"> = {
       : R
     : never;
 };
+export interface EditorAccentPhrase extends AccentPhrase {
+  editorID?: string;
+}
 
 /*
  * Audio Store Types
@@ -349,7 +356,12 @@ export type AudioStoreTypes = {
       accentPhrases: AccentPhrase[];
     };
   };
-
+  SET_ACCENT_PHRASES_EDITORID: {
+    mutation: {
+      audioKey: AudioKey;
+    };
+    action(payload: { audioKey: AudioKey }): void;
+  };
   SET_AUDIO_MORA_DATA: {
     mutation: {
       audioKey: AudioKey;

--- a/src/store/type.ts
+++ b/src/store/type.ts
@@ -51,6 +51,7 @@ import {
   engineIdSchema,
   styleIdSchema,
   EditorType,
+  AccentPhraseKey,
 } from "@/type/preload";
 import { IEngineConnectorFactory } from "@/infrastructures/EngineConnector";
 import {
@@ -60,6 +61,9 @@ import {
   LoadingScreenOption,
 } from "@/components/Dialog/Dialog";
 import { OverlappingNoteInfos } from "@/sing/storeHelper";
+
+/** エディタ用のAccentPhrase */
+export type EditorAccentPhrase = AccentPhrase & { key: AccentPhraseKey };
 
 /**
  * エディタ用のAudioQuery
@@ -129,9 +133,6 @@ export type StoreType<T, U extends "getter" | "mutation" | "action"> = {
       : R
     : never;
 };
-export interface EditorAccentPhrase extends AccentPhrase {
-  editorID?: string;
-}
 
 /*
  * Audio Store Types
@@ -320,8 +321,8 @@ export type AudioStoreTypes = {
   };
 
   SET_AUDIO_QUERY: {
-    mutation: { audioKey: AudioKey; audioQuery: AudioQuery };
-    action(payload: { audioKey: AudioKey; audioQuery: AudioQuery }): void;
+    mutation: { audioKey: AudioKey; audioQuery: EditorAudioQuery };
+    action(payload: { audioKey: AudioKey; audioQuery: EditorAudioQuery }): void;
   };
 
   FETCH_AUDIO_QUERY: {
@@ -329,7 +330,7 @@ export type AudioStoreTypes = {
       text: string;
       engineId: EngineId;
       styleId: StyleId;
-    }): Promise<AudioQuery>;
+    }): Promise<EditorAudioQuery>;
   };
 
   SET_AUDIO_VOICE: {
@@ -337,7 +338,7 @@ export type AudioStoreTypes = {
   };
 
   SET_ACCENT_PHRASES: {
-    mutation: { audioKey: AudioKey; accentPhrases: AccentPhrase[] };
+    mutation: { audioKey: AudioKey; accentPhrases: EditorAccentPhrase[] };
   };
 
   FETCH_ACCENT_PHRASES: {
@@ -346,22 +347,22 @@ export type AudioStoreTypes = {
       engineId: EngineId;
       styleId: StyleId;
       isKana?: boolean;
-    }): Promise<AccentPhrase[]>;
+    }): Promise<EditorAccentPhrase[]>;
   };
 
-  SET_SINGLE_ACCENT_PHRASE: {
-    mutation: {
-      audioKey: AudioKey;
-      accentPhraseIndex: number;
-      accentPhrases: AccentPhrase[];
-    };
-  };
-  SET_ACCENT_PHRASES_EDITORID: {
-    mutation: {
-      audioKey: AudioKey;
-    };
-    action(payload: { audioKey: AudioKey }): void;
-  };
+  // SET_SINGLE_ACCENT_PHRASE: {
+  //   mutation: {
+  //     audioKey: AudioKey;
+  //     accentPhraseIndex: number;
+  //     accentPhrases: AccentPhrase[];
+  //   };
+  // };
+  // SET_ACCENT_PHRASES_EDITORID: {
+  //   mutation: {
+  //     audioKey: AudioKey;
+  //   };
+  //   action(payload: { audioKey: AudioKey }): void;
+  // };
   SET_AUDIO_MORA_DATA: {
     mutation: {
       audioKey: AudioKey;
@@ -378,19 +379,19 @@ export type AudioStoreTypes = {
 
   FETCH_MORA_DATA: {
     action(payload: {
-      accentPhrases: AccentPhrase[];
+      accentPhrases: EditorAccentPhrase[];
       engineId: EngineId;
       styleId: StyleId;
-    }): Promise<AccentPhrase[]>;
+    }): Promise<EditorAccentPhrase[]>;
   };
 
   FETCH_AND_COPY_MORA_DATA: {
     action(payload: {
-      accentPhrases: AccentPhrase[];
+      accentPhrases: EditorAccentPhrase[];
       engineId: EngineId;
       styleId: StyleId;
       copyIndexes: number[];
-    }): Promise<AccentPhrase[]>;
+    }): Promise<EditorAccentPhrase[]>;
   };
 
   DEFAULT_PROJECT_FILE_BASE_NAME: {
@@ -501,8 +502,8 @@ export type AudioCommandStoreTypes = {
   COMMAND_CHANGE_AUDIO_TEXT: {
     mutation: { audioKey: AudioKey; text: string } & (
       | { update: "Text" }
-      | { update: "AccentPhrases"; accentPhrases: AccentPhrase[] }
-      | { update: "AudioQuery"; query: AudioQuery }
+      | { update: "AccentPhrases"; accentPhrases: EditorAccentPhrase[] }
+      | { update: "AudioQuery"; query: EditorAudioQuery }
     );
     action(payload: { audioKey: AudioKey; text: string }): void;
   };
@@ -514,11 +515,11 @@ export type AudioCommandStoreTypes = {
         AudioKey,
         | {
             update: "AccentPhrases";
-            accentPhrases: AccentPhrase[];
+            accentPhrases: EditorAccentPhrase[];
           }
         | {
             update: "AudioQuery";
-            query: AudioQuery;
+            query: EditorAudioQuery;
           }
         | {
             update: "OnlyVoice";
@@ -529,7 +530,7 @@ export type AudioCommandStoreTypes = {
   };
 
   COMMAND_CHANGE_ACCENT: {
-    mutation: { audioKey: AudioKey; accentPhrases: AccentPhrase[] };
+    mutation: { audioKey: AudioKey; accentPhrases: EditorAccentPhrase[] };
     action(payload: {
       audioKey: AudioKey;
       accentPhraseIndex: number;
@@ -538,7 +539,7 @@ export type AudioCommandStoreTypes = {
   };
 
   COMMAND_CHANGE_ACCENT_PHRASE_SPLIT: {
-    mutation: { audioKey: AudioKey; accentPhrases: AccentPhrase[] };
+    mutation: { audioKey: AudioKey; accentPhrases: EditorAccentPhrase[] };
     action(
       payload: { audioKey: AudioKey; accentPhraseIndex: number } & (
         | { isPause: false; moraIndex: number }
@@ -552,7 +553,7 @@ export type AudioCommandStoreTypes = {
   };
 
   COMMAND_CHANGE_SINGLE_ACCENT_PHRASE: {
-    mutation: { audioKey: AudioKey; accentPhrases: AccentPhrase[] };
+    mutation: { audioKey: AudioKey; accentPhrases: EditorAccentPhrase[] };
     action(payload: {
       audioKey: AudioKey;
       newPronunciation: string;

--- a/src/store/utility.ts
+++ b/src/store/utility.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import { Platform } from "quasar";
 import { diffArrays } from "diff";
+import { EditorAccentPhrase } from "./type";
 import {
   CharacterInfo,
   StyleInfo,
@@ -224,9 +225,12 @@ function skipMemoText(targettext: string): string {
  * 「 [こん]ばん[は] 」
  */
 export class TuningTranscription {
-  beforeAccent: AccentPhrase[];
-  afterAccent: AccentPhrase[];
-  constructor(beforeAccent: AccentPhrase[], afterAccent: AccentPhrase[]) {
+  beforeAccent: EditorAccentPhrase[];
+  afterAccent: EditorAccentPhrase[];
+  constructor(
+    beforeAccent: EditorAccentPhrase[],
+    afterAccent: EditorAccentPhrase[]
+  ) {
     this.beforeAccent = JSON.parse(JSON.stringify(beforeAccent));
     this.afterAccent = JSON.parse(JSON.stringify(afterAccent));
   }
@@ -305,8 +309,10 @@ export class TuningTranscription {
    * あとは一致したモーラを転写するだけ。
    *
    */
-  private mergeAccentPhrases(moraPatch: (Mora | undefined)[]): AccentPhrase[] {
-    const after: AccentPhrase[] = structuredClone(this.afterAccent);
+  private mergeAccentPhrases(
+    moraPatch: (Mora | undefined)[]
+  ): EditorAccentPhrase[] {
+    const after: EditorAccentPhrase[] = structuredClone(this.afterAccent);
     let moraPatchIndex = 0;
 
     // AccentPhrasesから[ accentIndex ]["moras"][ moraIndex ]でモーラが得られる。

--- a/src/type/preload.ts
+++ b/src/type/preload.ts
@@ -53,6 +53,11 @@ export const audioKeySchema = z.string().brand<"AudioKey">();
 export type AudioKey = z.infer<typeof audioKeySchema>;
 export const AudioKey = (id: string): AudioKey => audioKeySchema.parse(id);
 
+export const accentPhraseKeySchema = z.string().brand<"AccentPhraseKey">();
+export type AccentPhraseKey = z.infer<typeof accentPhraseKeySchema>;
+export const AccentPhraseKey = (id: string): AccentPhraseKey =>
+  accentPhraseKeySchema.parse(id);
+
 export const presetKeySchema = z.string().brand<"PresetKey">();
 export type PresetKey = z.infer<typeof presetKeySchema>;
 export const PresetKey = (id: string): PresetKey => presetKeySchema.parse(id);

--- a/tests/unit/store/utility.spec.ts
+++ b/tests/unit/store/utility.spec.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 import { AccentPhrase, Mora } from "@/openapi";
 import {
+  AccentPhraseKey,
   CharacterInfo,
   EngineId,
   SpeakerId,
@@ -26,6 +27,7 @@ import {
   isOnCommandOrCtrlKeyDown,
   filterCharacterInfosByStyleType,
 } from "@/store/utility";
+import { EditorAccentPhrase } from "@/store/type";
 
 function createDummyMora(text: string): Mora {
   return {
@@ -36,8 +38,9 @@ function createDummyMora(text: string): Mora {
   };
 }
 
-function createDummyAccentPhrase(moraTexts: string[]): AccentPhrase {
+function createDummyAccentPhrase(moraTexts: string[]): EditorAccentPhrase {
   return {
+    key: AccentPhraseKey(Math.random().toString()),
     moras: moraTexts.map(createDummyMora),
     accent: Math.random(),
   };
@@ -163,12 +166,12 @@ describe.each([
 
 describe("TuningTranscription", () => {
   it("２つ以上のアクセント句でも正しくデータを転写できる", async () => {
-    const before: AccentPhrase[] = [
+    const before: EditorAccentPhrase[] = [
       createDummyAccentPhrase(["い", "え"]),
       createDummyAccentPhrase(["か", "き", "く", "け", "こ"]),
       createDummyAccentPhrase(["さ", "し", "す", "せ", "そ"]),
     ];
-    const after: AccentPhrase[] = [
+    const after: EditorAccentPhrase[] = [
       createDummyAccentPhrase(["あ", "い", "う", "え", "お"]), // 最初・真ん中・最後に追加
       createDummyAccentPhrase(["き", "け"]), // 最初・真ん中・最後を消去
       createDummyAccentPhrase(["た", "ち", "つ", "て", "と"]), // すべて置き換え


### PR DESCRIPTION

https://github.com/VOICEVOX/voicevox/pull/1879

の提案のために作ってみたけど欠点に気づいて引き換えした。
変更が多すぎるのは別に良い。
一方で元の目的の「UIがアニメーションしないようにする」を達成しづらかった。

アクセント句をmerge/splitする際、accentPhraseのidを一緒にするか変えるか、id的にはどっちでも良いはず。
でもUI的には元のidどちらとも違っていたほうが良い。
ということで、なんかおかしい。

UIにとってのkeyなので、理想的にはコンポーネント内でだけkeyを持っている方が良いかも。
ただそうなるとmergeやsplitもコンポーネント内で完結しないといけない。
それはCOMMANDの実装的にまずいかもしれない。

というメモ